### PR TITLE
Correct fix for a markdown-tests.el byte-compilation warning, add tests.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,10 +11,15 @@ TEST_HTML = $(TEST_SRCS:.text=.html)
 	$(MARKDOWN) < $< > $@
 
 test:
-	$(EMACS) -Q -batch -l ert -l ../markdown-mode.el -l markdown-test.el \
+	$(EMACS) -Q --batch \
+	    --eval '(setq byte-compile-error-on-warn t)' \
+	    -l ../markdown-mode.el \
+	    -f batch-byte-compile ../markdown-mode.el markdown-test.el
+	$(EMACS) -Q --batch \
+	    -l ert -l ../markdown-mode.elc -l markdown-test.elc \
 	    -f ert-run-tests-batch-and-exit
 
 html: $(TEST_HTML)
 
 clean:
-	rm -f $(TEST_HTML)
+	rm -f $(TEST_HTML) *.elc ../*.elc

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -32,7 +32,7 @@
 
 (require 'markdown-mode)
 (require 'ert)
-(require 'cl)
+(require 'cl-lib)
 
 (defconst markdown-test-dir
    (expand-file-name (file-name-directory


### PR DESCRIPTION
bccb000 added "(require 'cl)" to markdown-test.el to fix a byte-compilation
warning, but it should have been "(require 'cl-lib)". This did not get caught
before because cl-lib was being autoloaded anyways, and the change was not
properly covered by automated tests.

This change fixes that, and adds tests for the byte-compilation of
markdown-mode.el and markdown-tests.el, running the tests from the byte-compiled
versions.