### PR TITLE
Set font style for GFM-style code blocks in base markdown-mode, too.

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1346,6 +1346,10 @@ on the value of `markdown-wiki-link-alias-first'.")
 
 (defvar markdown-mode-font-lock-keywords-basic
   (list
+   (cons 'markdown-match-gfm-code-blocks '((1 markdown-pre-face)
+                                           (2 markdown-language-keyword-face t t)
+                                           (3 markdown-pre-face)
+                                           (4 markdown-pre-face)))
    (cons 'markdown-match-fenced-code-blocks '((0 markdown-pre-face)))
    (cons 'markdown-match-pre-blocks '((0 markdown-pre-face)))
    (cons markdown-regex-blockquote 'markdown-blockquote-face)
@@ -1929,8 +1933,8 @@ because `thing-at-point-looking-at' does not work reliably with
 (defun markdown-match-gfm-code-blocks (last)
   "Match GFM quoted code blocks from point to LAST."
   (let (open lang body close all)
-    (cond ((and (eq major-mode 'gfm-mode)
-                (search-forward-regexp "^\\(```\\)\\([^[:space:]]+[[:space:]]*\\)?$" last t))
+    (cond ((search-forward-regexp
+            "^\\(```\\)\\([^[:space:]]+[[:space:]]*\\)?$" last t)
            (beginning-of-line)
            (setq open (list (match-beginning 1) (match-end 1))
                  lang (list (match-beginning 2) (match-end 2)))
@@ -2288,7 +2292,9 @@ location determined by `markdown-reference-location'."
                     (t (read-string "Link URL: "))))
          (title (cond
                  ((= (length url) 0) nil)
-                 (switch (substring (match-string 6) 1 -1))
+                 (switch (if (> (length (match-string 6)) 2)
+                             (substring (match-string 6) 1 -1)
+                           nil))
                  (t (read-string "Link Title (optional): ")))))
     (when bounds (delete-region (car bounds) (cdr bounds)))
     (markdown-insert-reference-link text label url title)))
@@ -4856,10 +4862,6 @@ if ARG is omitted or nil."
   (append
    ;; GFM features to match first
    (list
-    (cons 'markdown-match-gfm-code-blocks '((1 markdown-pre-face)
-                                            (2 markdown-language-keyword-face t t)
-                                            (3 markdown-pre-face)
-                                            (4 markdown-pre-face)))
     (cons markdown-regex-strike-through '(2 markdown-strike-through-face)))
    ;; Basic Markdown features (excluding possibly overridden ones)
    markdown-mode-font-lock-keywords-basic

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -998,7 +998,10 @@ Test point position upon removal and insertion."
   "Inline link to reference link conversion."
   (markdown-test-string "[text](http://jblevins.org/ \"title\")"
    (execute-kbd-macro (read-kbd-macro "M-x markdown-insert-reference-link-dwim RET 1 RET"))
-   (should (string-equal (buffer-string) "[text][1]\n\n[1]: http://jblevins.org/ \"title\"\n"))))
+   (should (string-equal (buffer-string) "[text][1]\n\n[1]: http://jblevins.org/ \"title\"\n")))
+  (markdown-test-string "[text](http://jblevins.org/)"
+   (execute-kbd-macro (read-kbd-macro "M-x markdown-insert-reference-link-dwim RET 1 RET"))
+   (should (string-equal (buffer-string) "[text][1]\n\n[1]: http://jblevins.org/\n"))))
 
 (ert-deftest test-markdown-insertion/inline-link ()
   "Basic tests for `markdown-insert-link'."
@@ -1790,6 +1793,14 @@ body"
   (markdown-test-string "    \nasdf  \n"
    (markdown-test-range-has-face 1 9 nil)
    (markdown-test-range-has-face 10 11 markdown-line-break-face)))
+
+(ert-deftest test-markdown-font-lock/gfm-code-block-font-lock ()
+  "GFM code block font lock test. Now in base markdown-mode as well!"
+  (markdown-test-file "gfm.text"
+    (markdown-test-range-has-face 2639 2641 markdown-pre-face) ; ```
+    (markdown-test-range-has-face 2642 2645 markdown-language-keyword-face) ; lang
+    (markdown-test-range-has-face 2647 2728 markdown-pre-face) ; code
+    (markdown-test-range-has-face 2730 2732 markdown-pre-face))) ; ```
 
 ;;; Markdown Parsing Functions:
 


### PR DESCRIPTION
Github Flavored Markdown isn't the only one that supports fenced-code blocks
annotated with a string controlling things like syntax highlighting. That's also
part of the Common Mark spec (http://spec.commonmark.org/0.20/#info-string).

There's room to be permissive here. The syntax for a GFM-style code block is
unlikely to show up in Markdown code in other contexts. And failing to do so
makes those code-blocks much harder to read in the source (e.g. because
Python comments are highlighted as headers and so on).