### PR TITLE
handle ikiwiki-style search for wikilinks

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4584,10 +4584,20 @@ and [[test test]] both map to Test-test.ext."
     (when (eq major-mode 'gfm-mode)
       (setq basename (concat (upcase (substring basename 0 1))
                              (downcase (substring basename 1 nil)))))
-    (concat basename
-            (if (buffer-file-name)
-                (concat "."
-                        (file-name-extension (buffer-file-name)))))))
+    (let* ((default
+            (concat basename
+                    (if (buffer-file-name)
+                        (concat "."
+                                (file-name-extension (buffer-file-name))))))
+           (current default))
+      (catch 'done
+        (loop
+         (if (file-exists-p current)
+             (throw 'done current))
+         (if (string-equal (expand-file-name current)
+                           (concat "/" default))
+             (throw 'done default))
+         (setq current (concat "../" current)))))))
 
 (defun markdown-follow-wiki-link (name &optional other)
   "Follow the wiki link NAME.
@@ -4597,7 +4607,8 @@ window when OTHER is non-nil."
   (let ((filename (markdown-convert-wiki-link-to-filename name))
         (wp (file-name-directory buffer-file-name)))
     (when other (other-window 1))
-    (find-file (concat wp filename)))
+    (let ((default-directory wp))
+      (find-file filename)))
   (when (not (eq major-mode 'markdown-mode))
     (markdown-mode)))
 


### PR DESCRIPTION
ikiwiki (at <http://ikiwiki.info/>) supports searching for wikilink
targets not just relative to the current directory, but also relative to
parent directories (up to the wiki root).

This patch supports that search unconditionally.  It also goes beyond
the wiki root, because the emacs mode has no way of knowing where that
root is.  I hope that I have got the termination logic right but the
platform where it's most likely to be wrong (Windows) is currently
inaccessible to me.