### PR TITLE
give wiki-link variables safety annotations

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -893,13 +893,15 @@ auto-indentation by pressing \\[newline-and-indent]."
   "When non-nil, treat aliased wiki links like [[alias text|PageName]].
 Otherwise, they will be treated as [[PageName|alias text]]."
   :group 'markdown
-  :type 'boolean)
+  :type 'boolean
+  :safe 'booleanp)
 
 (defcustom markdown-wiki-link-search-parent-directories nil
   "When non-nil, search for wiki link targets in parent directories.
 This is the default search behavior of Ikiwiki."
   :group 'markdown
-  :type 'boolean)
+  :type 'boolean
+  :safe 'booleanp)
 
 (defcustom markdown-uri-types
   '("acap" "cid" "data" "dav" "fax" "file" "ftp" "gopher" "http" "https"


### PR DESCRIPTION
these wiki-link variables are potentially customized per-file or
per-project (in e.g. a .dir-locals.el file).  Specify that they are
`safe' to have boolean values.