### PR TITLE
Ikiwiki tests

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4739,7 +4739,8 @@ and [[test test]] both map to Test-test.ext."
                              (downcase (substring basename 1 nil)))))
     (let* ((default
             (concat basename
-                    (if (buffer-file-name)
+                    (if (and (buffer-file-name)
+                             (file-name-extension (buffer-file-name)))
                         (concat "."
                                 (file-name-extension (buffer-file-name))))))
            (current default))

--- a/tests/ikiwiki/root
+++ b/tests/ikiwiki/root
@@ -1,0 +1,3 @@
+[[sub/foo]]
+
+[[sub/doesnotexist]]

--- a/tests/ikiwiki/sub/foo
+++ b/tests/ikiwiki/sub/foo
@@ -1,0 +1,3 @@
+[[doesnotexist]]
+
+[[root]]

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2832,6 +2832,27 @@ indented the same amount."
     (markdown-indent-region (line-beginning-position) (line-end-position) nil)
     (should (string-equal (buffer-string) " #. abc\n    def\n"))))
 
+(ert-deftest test-markdown-ext/ikiwiki ()
+  (let ((markdown-wiki-link-search-parent-directories t))
+    (progn
+      (find-file "ikiwiki/root")
+      (unwind-protect
+          (progn
+            (markdown-mode)
+            ;; font lock
+            (markdown-test-range-has-property 1 11 'font-lock-face markdown-link-face)
+            (markdown-test-range-has-property 14 33 'font-lock-face markdown-missing-link-face))
+        (kill-buffer)))
+    (progn
+      (find-file "ikiwiki/sub/foo")
+      (unwind-protect
+          (progn
+            (markdown-mode)
+            ;; font lock
+            (markdown-test-range-has-property 1 16 'font-lock-face markdown-missing-link-face)
+            (markdown-test-range-has-property 19 26 'font-lock-face markdown-link-face))
+        (kill-buffer)))))
+
 (provide 'markdown-test)
 
 ;;; markdown-test.el ends here


### PR DESCRIPTION
an attempt at writing tests for the ikiwiki-like parent directory search for wikilink targets.

I got thoroughly lost by font-lock weirdness when writing this; differences in behaviour when run interactively and in batch mode are weird.  (Even without my modifications, I think a number of tests
fail when run in a live emacs with `ert-run-tests-interactively`, so...)

Nevertheless, with this `make test` succeeds.