### PR TITLE
add asymmetric header styling option, which most folk use these days

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,10 @@ provides an interface to all of the possible customizations:
   * `markdown-italic-underscore` - set to a non-nil value to use
     underscores for italic instead of asterisks (default: `nil`).
 
+  * `markdown-asymmetric-header` - set to a non-nil value to use
+    asymmetric header styling, placing header characters only on
+    the left of headers (default: `nil`).
+
   * `markdown-indent-function` - the function to use for automatic
     indentation (default: `markdown-indent-line`).
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -490,6 +490,10 @@
 ;;   * `markdown-italic-underscore' - set to a non-nil value to use
 ;;     underscores for italic instead of asterisks (default: `nil').
 ;;
+;;   * `markdown-asymmetric-header' - set to a non-nil value to use
+;;     asymmetric header styling, placing header characters only on
+;;     the left of headers (default: `nil').
+;;
 ;;   * `markdown-indent-function' - the function to use for automatic
 ;;     indentation (default: `markdown-indent-line').
 ;;
@@ -872,6 +876,14 @@ promotion and demotion functions."
 
 (defcustom markdown-italic-underscore nil
   "Use underscores for italic instead of asterisks."
+  :group 'markdown
+  :type 'boolean)
+
+(defcustom markdown-asymmetric-header nil
+  "Determines if header style will be asymmetric.
+Set to non-nil to only have header characters to the left of the title.
+The default will ensure header characters are placed to the left and right
+of the title."
   :group 'markdown
   :type 'boolean)
 
@@ -2593,7 +2605,7 @@ header will be inserted."
            (insert text "\n" hdr))
           (t
            (setq hdr (make-string level ?#))
-           (insert hdr " " text " " hdr))))
+           (insert hdr " " text (when (null markdown-asymmetric-header) " " hdr)))))
   (markdown-ensure-blank-line-after)
   ;; Leave point at end of text
   (if setext


### PR DESCRIPTION
This creates a new customization variable, `markdown-asymmetric-header`.  Set to non-nil to only have header characters to the left of the title. The default will ensure header characters are placed to the left and right of the title.

For example, if set, headers will be styled like so:

```
### foo bar
```

instead of like this

```
### foo bar ###
```
