### PR TITLE
Modified markdown-regex-header to require a space between # and heading text

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1302,7 +1302,7 @@ Group 2 matches only the label, without the surrounding markup.
 Group 3 matches the closing square bracket.")
 
 (defconst markdown-regex-header
-  "^\\(?:\\(.+\\)\n\\(=+\\)\\|\\(.+\\)\n\\(-+\\)\\|\\(#+\\)\\s-*\\(.*?\\)\\s-*?\\(#*\\)\\)$"
+  "^\\(?:\\(.+\\)\n\\(=+\\)\\|\\(.+\\)\n\\(-+\\)\\|\\(#+\\)\\s-+\\(.*?\\)\\s-*?\\(#*\\)\\)$"
   "Regexp identifying Markdown headers.")
 
 (defconst markdown-regex-header-1-atx


### PR DESCRIPTION
When a markdown document contains a code block for a language that uses # as a comment character, folding is broken. For example, in the following markdown text:

```
# Heading One

` ``r
#Comment on code
myFunction <- function
` ``

## Subheading A
```
Folding the first header produces the following:

```
# Heading One
#Comment on code
myFunction <- function
` ``

## Subheading A
```

In effect, my code comment is treated as a heading for the folding algorithm.

A simple fix is updating the heading regexp to **require** a space (\s-+), rather than allow a space (\s-*), after the opening # symbols. This appears to be consistent with the markdown specification, in which all headlines are of the form "# Heading 1" rather than "#Heading 1". 

As a consequence, in code blocks we cannot use a space between the # and the code. The alternative would require detecting and ignoring lines that occur in a code block, which would be more involved.

Thanks for your time,

Tyler
