### PR TITLE
add markdown-native-preview-mode to view previewed output within emacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,14 @@ keybindings by pressing <kbd>C-c C-h</kbd>.
     and save the result in the file `basename.html`, where
     `basename` is the name of the Markdown file with the extension
     removed.  *Export and View:* press <kbd>C-c C-c v</kbd> to export the
-    file and view it in a browser.  **For both export commands, the
-    output file will be overwritten without notice.**
-    *Open:* <kbd>C-c C-c o</kbd> will open the Markdown source file directly
-    using `markdown-open-command`.
+    file and view it in a browser.  *Open:* <kbd>C-c C-c o</kbd> will open
+    the Markdown source file directly using `markdown-open-command`.
+    *Live Export*: Press <kbd>C-c C-c l</kbd> to turn on
+    `markdown-live-preview-mode` to view the exported output
+    side-by-side with the source Markdown. **For all export commands,
+    the output file will be overwritten without notice.**
+    `markdown-live-preview-window-function` can be customized to open
+    in a browser other than `eww`.
 
     To summarize:
 
@@ -221,6 +225,7 @@ keybindings by pressing <kbd>C-c C-h</kbd>.
       - <kbd>C-c C-c v</kbd>: `markdown-command` > `basename.html` > browser.
       - <kbd>C-c C-c w</kbd>: `markdown-command` > kill ring.
       - <kbd>C-c C-c o</kbd>: `markdown-open-command`.
+      - <kbd>C-c C-c l</kbd>: `markdown-live-preview-mode` > `*eww*` buffer.
 
     <kbd>C-c C-c c</kbd> will check for undefined references.  If there are
     any, a small buffer will open with a list of undefined

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4657,7 +4657,6 @@ current filename, but with the extension removed and replaced with .html."
       (with-current-buffer output-buffer
         (run-hooks 'markdown-after-export-hook)
         (save-buffer))
-      (kill-buffer output-buffer)
       ;; if modified, restore initial buffer
       (when (buffer-modified-p init-buf)
         (erase-buffer)
@@ -4698,7 +4697,9 @@ emacs using `markdown-preview-window-function'."
       (when (and markdown-native-preview-delete-export
                  export-file
                  (file-exists-p export-file))
-        (delete-file export-file)))))
+        (delete-file export-file)
+        (let ((buf (get-file-buffer export-file)))
+          (when buf (kill-buffer buf)))))))
 
 (defun markdown-remove-native-preview ()
   (when (buffer-live-p markdown-preview-buffer)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4701,7 +4701,8 @@ non-nil."
 
 (defun markdown-live-preview-export ()
   "Export to XHTML using `markdown-export' and browse the resulting file within
-Emacs using `markdown-live-preview-window-function'."
+Emacs using `markdown-live-preview-window-function' Return the buffer displaying
+the rendered output."
   (interactive)
   (let ((export-file (markdown-export))
         ;; get positions in all windows currently displaying output buffer
@@ -4719,11 +4720,9 @@ Emacs using `markdown-live-preview-window-function'."
     ;; the new output
     (mapc #'markdown-live-preview-window-deserialize window-data)
     (when (and markdown-live-preview-delete-export
-               export-file
-               (file-exists-p export-file))
+               export-file (file-exists-p export-file))
       (delete-file export-file)
-      (let ((buf (get-file-buffer export-file)))
-        (when buf (kill-buffer buf))))
+      (let ((buf (get-file-buffer export-file))) (when buf (kill-buffer buf))))
     markdown-live-preview-buffer))
 
 (defun markdown-live-preview-remove ()

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4680,8 +4680,8 @@ emacs using `markdown-preview-window-function'."
       (if (not preview-windows) (unless arg (display-buffer preview-buf))
         (mapc
          (lambda (window-and-point)
-           (set-window-buffer (car window-pair) preview-buf)
-           (set-window-point win (cdr window-pair)))
+           (set-window-buffer (car window-and-point) preview-buf)
+           (set-window-point (car window-and-point) (cdr window-and-point)))
          (mapcar (lambda (window) (cons window (window-point window)))
                  preview-windows)))
       (when (buffer-live-p markdown-preview-buffer)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5305,7 +5305,7 @@ before regenerating font-lock rules for extensions."
   (markdown-fontify-buffer-wiki-links))
 
 
-;;; Native Preview Mode  ============================================
+;;; Live Preview Mode  ============================================
 (define-minor-mode markdown-live-preview-mode
   "Toggle native previewing on save for a specific markdown file."
   :lighter " MD-Preview"

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4651,6 +4651,7 @@ current filename, but with the extension removed and replaced with .html."
       (with-current-buffer output-buffer
         (run-hooks 'markdown-after-export-hook)
         (save-buffer))
+      (kill-buffer output-buffer)
       ;; if modified, restore initial buffer
       (when (buffer-modified-p init-buf)
         (erase-buffer)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4694,9 +4694,10 @@ non-nil."
   "Apply window point and scroll data from WINDOW-POSNS, given by
 `markdown-live-preview-window-serialize'."
   (destructuring-bind (win pt start) window-posns
-    (set-window-buffer win markdown-live-preview-buffer)
-    (set-window-point win pt)
-    (set-window-start win start)))
+    (when (window-live-p win)
+      (set-window-buffer win markdown-live-preview-buffer)
+      (set-window-point win pt)
+      (set-window-start win start))))
 
 (defun markdown-live-preview-export ()
   "Export to XHTML using `markdown-export' and browse the resulting file within

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4683,7 +4683,7 @@ current filename, but with the extension removed and replaced with .html."
 
 (defun markdown-window-redisplay-preview (buf display-args)
   "Redisplay a window previewing the exported output of a markdown
-buffer. DISPLAY-ARGS is a list with 4 elements of the form
+buffer BUF. DISPLAY-ARGS is a list with 4 elements of the form
 (window point start)."
   (destructuring-bind (window point start) display-args
     (set-window-buffer window buf)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5316,7 +5316,6 @@ before regenerating font-lock rules for extensions."
         (t (markdown-live-preview-remove))))
 
 (add-hook 'after-save-hook #'markdown-live-preview-if-markdown)
-(add-hook 'after-revert-hook #'markdown-live-preview-if-markdown)
 (add-hook 'kill-buffer-hook #'markdown-live-preview-remove-on-kill)
 
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1010,7 +1010,7 @@ to `nil' instead. See `font-lock-support-mode' for more details."
 
 (defcustom markdown-live-preview-window-function 'markdown-live-preview-window-eww
   "Function to display preview of Markdown output within Emacs. Function must
-update the buffer containing the preview and return the buffer name."
+update the buffer containing the preview and return the buffer."
   :group 'markdown
   :type 'function)
 

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -38,6 +38,9 @@
   (expand-file-name (file-name-directory
                      (or load-file-name buffer-file-name))))
 
+(defconst markdown-test-font-lock-function
+  (if noninteractive #'font-lock-ensure #'font-lock-fontify-buffer))
+
 (defmacro markdown-test-string-mode (mode string &rest body)
   "Run BODY in a temporary buffer containing STRING in MODE."
   `(let ((win (selected-window)))
@@ -49,7 +52,7 @@
            (setq-default indent-tabs-mode nil)
            (insert ,string)
            (goto-char (point-min))
-           (font-lock-fontify-buffer)
+           (funcall markdown-test-font-lock-function)
            (prog1 ,@body (kill-buffer))))))
 
 (defmacro markdown-test-file-mode (mode file &rest body)
@@ -60,7 +63,7 @@
          (insert-file-contents fn)
          (funcall ,mode)
          (goto-char (point-min))
-         (font-lock-fontify-buffer)
+         (funcall markdown-test-font-lock-function)
          ,@body))))
 
 (defmacro markdown-test-string (string &rest body)
@@ -94,7 +97,7 @@ This file is not saved."
        (insert-file-contents fn)
        (markdown-mode)
        (goto-char (point-min))
-       (font-lock-fontify-buffer)
+       (funcall markdown-test-font-lock-function)
        ,@body
        (set-buffer-modified-p nil)
        (kill-buffer buf)
@@ -2736,7 +2739,7 @@ indented the same amount."
   "Test markdown math mode."
   (markdown-test-file "math.text"
    (markdown-enable-math t)
-   (font-lock-fontify-buffer)
+   (funcall markdown-test-font-lock-function)
    (markdown-test-range-has-face 1 32 nil)
    (markdown-test-range-has-face 33 33 markdown-markup-face)
    (markdown-test-range-has-face 34 45 markdown-math-face)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -39,7 +39,8 @@
                      (or load-file-name buffer-file-name))))
 
 (defconst markdown-test-font-lock-function
-  (if noninteractive #'font-lock-ensure #'font-lock-fontify-buffer))
+  (if (and noninteractive (fboundp 'font-lock-ensure))
+      #'font-lock-ensure #'font-lock-fontify-buffer))
 
 (defmacro markdown-test-string-mode (mode string &rest body)
   "Run BODY in a temporary buffer containing STRING in MODE."


### PR DESCRIPTION
`markdown-export-and-preview` is great for running glossy live-updating markdown viewer nightmare children and is very idiomatic emacs lisp. `markdown-native-preview-mode` is an alternative using `eww` (built in to emacs since 24.4) to view compiled HTML output within emacs, live-updating as the file is saved. The function `markdown-export-native-preview` will run `markdown-export`, then open `eww` to the exported file. If `eww` is not already displaying a preview of the exported output, it will pop to a new `eww` buffer displaying it; otherwise, it will update all windows displaying the exported output to their respective points in a new eww buffer rendering the new export. If `markdown-native-preview-mode` is turned on, rendering occurs synchronously on every save.

The defcustom `markdown-preview-window-function` can be used to customize the method of displaying the exported output in emacs, allowing the user to choose an alternative html viewer within emacs such as `w3m`. The defcustom `markdown-native-preview-delete-export` determines whether to delete the exported file, which is typically not required after rendering within emacs, unlike with external html viewers.