### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: generic
+sudo: false
+before_install:
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
+  - evm install $EVM_EMACS --use --skip
+env:
+  - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
+script:
+  - emacs --version
+  - cd tests && make clean && make test

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -796,6 +796,8 @@
 (require 'thingatpt)
 (eval-when-compile (require 'cl))
 
+(declare-function eww-open-file "eww")
+
 
 ;;; Constants =================================================================
 


### PR DESCRIPTION
Don't test Emacs 24.3 or lower version. Because eww was introduced at
Emacs 24.4 and byte-compile test is failed on older version.

Test result sample is here
- https://travis-ci.org/syohex/markdown-mode

You need to setup for enabling CI of this repository from your travis profile page.

See also
- https://docs.travis-ci.com/user/getting-started/