### PR TITLE
add testing for live-preview-*, and fixes

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5142,6 +5142,7 @@ buffer. Inverse of `markdown-live-preview-buffer'.")
 
 (defun markdown-live-preview-window-eww (file)
   "A `markdown-live-preview-window-function' for previewing with eww."
+  (require 'eww)
   (eww-open-file file)
   (get-buffer "*eww*"))
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5142,9 +5142,11 @@ buffer. Inverse of `markdown-live-preview-buffer'.")
 
 (defun markdown-live-preview-window-eww (file)
   "A `markdown-live-preview-window-function' for previewing with eww."
-  (require 'eww)
-  (eww-open-file file)
-  (get-buffer "*eww*"))
+  (if (eval-when-compile (featurep 'eww))
+      (progn
+        (eww-open-file file)
+        (get-buffer "*eww*"))
+    (error "eww is not present on this version of emacs")))
 
 (defun markdown-live-preview-window-serialize (buf)
   "Get window point and scroll data for all windows displaying BUF if BUF is

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1054,7 +1054,8 @@ update the buffer containing the preview and return the buffer."
 (defcustom markdown-live-preview-delete-export 'delete-on-destroy
   "Delete exported html file when using `markdown-live-preview-export' on every
 export by setting to 'delete-on-export, when quitting
-`markdown-live-preview-mode' by setting to 'delete-on-destroy, or not at all."
+`markdown-live-preview-mode' by setting to 'delete-on-destroy, or not at all
+when nil."
   :group 'markdown
   :type 'symbol)
 
@@ -5132,6 +5133,7 @@ current filename, but with the extension removed and replaced with .html."
 (defvar-local markdown-live-preview-source-buffer nil
   "Buffer with markdown source generating the source of the current
 buffer. Inverse of `markdown-live-preview-buffer'.")
+(defvar markdown-live-preview-currently-exporting nil)
 
 (defun markdown-live-preview-get-filename ()
   "Standardize the filename exported by `markdown-live-preview-export'."
@@ -5163,29 +5165,31 @@ non-nil."
 Emacs using `markdown-live-preview-window-function' Return the buffer displaying
 the rendered output."
   (interactive)
-  (let ((export-file (markdown-export (markdown-live-preview-get-filename)))
-        ;; get positions in all windows currently displaying output buffer
-        (window-data
-         (markdown-live-preview-window-serialize markdown-live-preview-buffer))
-        (cur-buf (current-buffer)))
+  (let* ((markdown-live-preview-currently-exporting t)
+         (cur-buf (current-buffer))
+         (export-file (markdown-export (markdown-live-preview-get-filename)))
+         ;; get positions in all windows currently displaying output buffer
+         (window-data
+          (markdown-live-preview-window-serialize
+           markdown-live-preview-buffer)))
     (save-window-excursion
-      ;; protect against `markdown-live-preview-window-function' changing
-      ;; `current-buffer'
       (let ((output-buffer
              (funcall markdown-live-preview-window-function export-file)))
         (with-current-buffer output-buffer
           (setq markdown-live-preview-source-buffer cur-buf))
         (with-current-buffer cur-buf
           (setq markdown-live-preview-buffer output-buffer))))
-    ;; reset all windows displaying output buffer to where they were, now with
-    ;; the new output
-    (mapc #'markdown-live-preview-window-deserialize window-data)
-    ;; delete html editing buffer
-    (let ((buf (get-file-buffer export-file))) (when buf (kill-buffer buf)))
-    (when (and (eq markdown-live-preview-delete-export 'delete-on-export)
-               export-file (file-exists-p export-file))
-      (delete-file export-file))
-    markdown-live-preview-buffer))
+    (with-current-buffer cur-buf
+      ;; reset all windows displaying output buffer to where they were,
+      ;; now with the new output
+      (mapc #'markdown-live-preview-window-deserialize window-data)
+      ;; delete html editing buffer
+      (let ((buf (get-file-buffer export-file))) (when buf (kill-buffer buf)))
+      (when (and export-file (file-exists-p export-file)
+                 (eq markdown-live-preview-delete-export
+                     'delete-on-export))
+        (delete-file export-file))
+      markdown-live-preview-buffer)))
 
 (defun markdown-live-preview-remove ()
   (when (buffer-live-p markdown-live-preview-buffer)
@@ -5200,9 +5204,10 @@ the rendered output."
 (defun markdown-live-preview-if-markdown ()
   (when (and (derived-mode-p 'markdown-mode)
              markdown-live-preview-mode)
-    (if (buffer-live-p markdown-live-preview-buffer)
-        (markdown-live-preview-export)
-      (switch-to-buffer-other-window (markdown-live-preview-export)))))
+    (unless markdown-live-preview-currently-exporting
+      (if (buffer-live-p markdown-live-preview-buffer)
+          (markdown-live-preview-export)
+        (display-buffer (markdown-live-preview-export))))))
 
 (defun markdown-live-preview-remove-on-kill ()
   (cond ((and (derived-mode-p 'markdown-mode)
@@ -5218,7 +5223,7 @@ the rendered output."
   "Turn on `markdown-live-preview-mode' if not already on, and switch to its
 output buffer in another window."
   (if markdown-live-preview-mode
-      (switch-to-buffer-other-window (markdown-live-preview-export)))
+      (display-buffer (markdown-live-preview-export)))
     (markdown-live-preview-mode))
 
 (defun markdown-open ()
@@ -5793,9 +5798,9 @@ before regenerating font-lock rules for extensions."
 (define-minor-mode markdown-live-preview-mode
   "Toggle native previewing on save for a specific markdown file."
   :lighter " MD-Preview"
-  (cond (markdown-live-preview-mode
-         (switch-to-buffer-other-window (markdown-live-preview-export)))
-        (t (markdown-live-preview-remove))))
+  (if markdown-live-preview-mode
+      (display-buffer (markdown-live-preview-export))
+    (markdown-live-preview-remove)))
 
 (add-hook 'after-save-hook #'markdown-live-preview-if-markdown)
 (add-hook 'kill-buffer-hook #'markdown-live-preview-remove-on-kill)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5016,7 +5016,8 @@ Insert the output in the buffer named OUTPUT-BUFFER-NAME."
 When OUTPUT-BUFFER-NAME is given, insert the output in the buffer with
 that name."
   (interactive)
-  (display-buffer (markdown-standalone output-buffer-name)))
+  (markdown-display-buffer-other-window
+   (markdown-standalone output-buffer-name)))
 
 (defun markdown-output-standalone-p ()
   "Determine whether `markdown-command' output is standalone XHTML.
@@ -5201,13 +5202,19 @@ the rendered output."
       (when (file-exists-p outfile-name)
         (delete-file outfile-name)))))
 
+(defun markdown-display-buffer-other-window (buf)
+  (let ((cur-buf (current-buffer)))
+    (switch-to-buffer-other-window buf)
+    (set-buffer cur-buf)))
+
 (defun markdown-live-preview-if-markdown ()
   (when (and (derived-mode-p 'markdown-mode)
              markdown-live-preview-mode)
     (unless markdown-live-preview-currently-exporting
       (if (buffer-live-p markdown-live-preview-buffer)
           (markdown-live-preview-export)
-        (display-buffer (markdown-live-preview-export))))))
+        (markdown-display-buffer-other-window
+         (markdown-live-preview-export))))))
 
 (defun markdown-live-preview-remove-on-kill ()
   (cond ((and (derived-mode-p 'markdown-mode)
@@ -5223,7 +5230,7 @@ the rendered output."
   "Turn on `markdown-live-preview-mode' if not already on, and switch to its
 output buffer in another window."
   (if markdown-live-preview-mode
-      (display-buffer (markdown-live-preview-export)))
+      (markdown-display-buffer-other-window (markdown-live-preview-export)))
     (markdown-live-preview-mode))
 
 (defun markdown-open ()
@@ -5799,7 +5806,7 @@ before regenerating font-lock rules for extensions."
   "Toggle native previewing on save for a specific markdown file."
   :lighter " MD-Preview"
   (if markdown-live-preview-mode
-      (display-buffer (markdown-live-preview-export))
+      (markdown-display-buffer-other-window (markdown-live-preview-export))
     (markdown-live-preview-remove)))
 
 (add-hook 'after-save-hook #'markdown-live-preview-if-markdown)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -44,6 +44,7 @@
 
 (defmacro markdown-test-string-mode (mode string &rest body)
   "Run BODY in a temporary buffer containing STRING in MODE."
+  (declare (indent 2))
   `(let ((win (selected-window)))
      (unwind-protect
          (with-temp-buffer
@@ -58,6 +59,7 @@
 
 (defmacro markdown-test-file-mode (mode file &rest body)
   "Open FILE from `markdown-test-dir' in MODE and execute BODY."
+  (declare (indent 2))
   `(let ((fn (concat markdown-test-dir ,file)))
      (save-window-excursion
        (with-temp-buffer
@@ -69,40 +71,47 @@
 
 (defmacro markdown-test-string (string &rest body)
   "Run body in a temporary buffer containing STRING in `markdown-mode'."
+  (declare (indent 1))
   `(markdown-test-string-mode 'markdown-mode ,string ,@body))
 (def-edebug-spec markdown-test-string (form body))
 
 (defmacro markdown-test-file (file &rest body)
   "Open FILE from `markdown-test-dir' in `markdown-mode' and execute BODY."
+  (declare (indent 1))
   `(markdown-test-file-mode 'markdown-mode ,file ,@body))
 (def-edebug-spec markdown-test-file (form body))
 
 (defmacro markdown-test-string-gfm (string &rest body)
   "Run body in a temporary buffer containing STRING in `gfm-mode'."
+  (declare (indent 1))
   `(markdown-test-string-mode 'gfm-mode ,string ,@body))
 (def-edebug-spec markdown-test-string-gfm (form body))
 
 (defmacro markdown-test-file-gfm (file &rest body)
   "Open FILE from `markdown-test-dir' in `gfm-mode' and execute BODY."
+  (declare (indent 1))
   `(markdown-test-file-mode 'gfm-mode ,file ,@body))
 (def-edebug-spec markdown-test-file-gfm (form body))
 
 (defmacro markdown-test-temp-file (file &rest body)
   "Open FILE from `markdown-test-dir' visiting temp file and execute body.
 This file is not saved."
+  (declare (indent 1))
   `(let ((fn (concat markdown-test-dir ,file))
          (tmp (make-temp-file "markdown-test" nil ".text"))
          buf)
      (save-window-excursion
-       (setq buf (find-file tmp))
-       (insert-file-contents fn)
-       (markdown-mode)
-       (goto-char (point-min))
-       (funcall markdown-test-font-lock-function)
-       ,@body
-       (set-buffer-modified-p nil)
-       (kill-buffer buf)
-       (delete-file tmp))))
+       (unwind-protect
+           (progn
+             (setq buf (find-file tmp))
+             (insert-file-contents fn)
+             (markdown-mode)
+             (goto-char (point-min))
+             (funcall markdown-test-font-lock-function)
+             ,@body
+             (set-buffer-modified-p nil))
+         (when (buffer-live-p buf) (kill-buffer buf))
+         (delete-file tmp)))))
 (def-edebug-spec markdown-test-temp-file (form body))
 
 (defun markdown-test-range-has-property (begin end prop value)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3205,6 +3205,41 @@ indented the same amount."
             (markdown-test-range-has-property 19 26 'font-lock-face markdown-link-face))
         (kill-buffer)))))
 
+(ert-deftest test-markdown-ext/live-preview-exports ()
+  (markdown-test-temp-file "inline.text"
+    (markdown-live-preview-mode)
+    (should (buffer-live-p markdown-live-preview-buffer))
+    (should (eq (current-buffer)
+                (with-current-buffer markdown-live-preview-buffer
+                  markdown-live-preview-source-buffer)))
+    (kill-buffer markdown-live-preview-buffer)
+    (should (null markdown-live-preview-buffer))
+    (set-buffer-modified-p t)
+    (save-buffer)                       ; should create new export
+    (should (buffer-live-p markdown-live-preview-buffer))))
+
+(ert-deftest test-markdown-ext/live-preview-delete-exports ()
+  (let ((markdown-live-preview-delete-export 'delete-on-destroy)
+        file-output)
+    (markdown-test-temp-file "inline.text"
+      (markdown-live-preview-mode)
+      (setq file-output (markdown-export-file-name)))
+    (should-not (file-exists-p file-output)))
+  (let ((markdown-live-preview-delete-export 'delete-on-export)
+        file-output)
+    (markdown-test-temp-file "inline.text"
+      (markdown-live-preview-mode)
+      (setq file-output (markdown-export-file-name))
+      (should-not (file-exists-p file-output))))
+  (let ((markdown-live-preview-delete-export nil)
+        file-output)
+    (unwind-protect
+        (markdown-test-temp-file "inline.text"
+          (markdown-live-preview-mode)
+          (setq file-output (markdown-export-file-name))
+          (should (file-exists-p file-output)))
+      (delete-file file-output))))
+
 (provide 'markdown-test)
 
 ;;; markdown-test.el ends here


### PR DESCRIPTION
After testing `live-preview-*` functions, I found a few silly things I was doing, like `markdown-live-preview-export` modifying `(current-buffer)`. These have been fixed now, so this pull request does three things (in order of the commits):

1. Add indentation properties to `defmacro` forms in the test suite so they can be automatically indented (this does not affect anything important at all), and add an `unwind-protect` around one of the test macros so temporary files get cleaned up.
2. Actually add tests for the live-preview functionality, including the feature which was just added in #49.
3. Fixes an issue with `display-buffer` not displaying a buffer in another window when it really should. This commit also affects the defun `markdown-other-window`.