### PR TITLE
Fix/cleanup eww live export

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5146,10 +5146,12 @@ buffer. Inverse of `markdown-live-preview-buffer'.")
 
 (defun markdown-live-preview-window-eww (file)
   "A `markdown-live-preview-window-function' for previewing with eww."
-  (if (eval-when-compile (featurep 'eww))
+  (if (or (fboundp 'eww-open-file)
+          (ignore-errors (autoload 'eww-open-file "eww")))
       (progn
         (eww-open-file file)
         (get-buffer "*eww*"))
+    (markdown-live-preview-mode -1)
     (error "eww is not present on this version of emacs")))
 
 (defun markdown-live-preview-window-serialize (buf)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5146,12 +5146,11 @@ buffer. Inverse of `markdown-live-preview-buffer'.")
 
 (defun markdown-live-preview-window-eww (file)
   "A `markdown-live-preview-window-function' for previewing with eww."
-  (if (fboundp 'eww-open-file)
+  (if (featurep 'eww)
       (progn
         (eww-open-file file)
         (get-buffer "*eww*"))
-    (markdown-live-preview-mode -1)
-    (error "eww is not present or not loaded on this version of emacs")))
+    (error "eww is not present on this version of emacs")))
 
 (defun markdown-live-preview-window-serialize (buf)
   "Get window point and scroll data for all windows displaying BUF if BUF is

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5146,13 +5146,12 @@ buffer. Inverse of `markdown-live-preview-buffer'.")
 
 (defun markdown-live-preview-window-eww (file)
   "A `markdown-live-preview-window-function' for previewing with eww."
-  (if (or (fboundp 'eww-open-file)
-          (ignore-errors (autoload 'eww-open-file "eww")))
+  (if (fboundp 'eww-open-file)
       (progn
         (eww-open-file file)
         (get-buffer "*eww*"))
     (markdown-live-preview-mode -1)
-    (error "eww is not present on this version of emacs")))
+    (error "eww is not present or not loaded on this version of emacs")))
 
 (defun markdown-live-preview-window-serialize (buf)
   "Get window point and scroll data for all windows displaying BUF if BUF is

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5150,7 +5150,7 @@ buffer. Inverse of `markdown-live-preview-buffer'.")
       (progn
         (eww-open-file file)
         (get-buffer "*eww*"))
-    (error "eww is not present on this version of emacs")))
+    (error "eww is not present or not loaded on this version of emacs")))
 
 (defun markdown-live-preview-window-serialize (buf)
   "Get window point and scroll data for all windows displaying BUF if BUF is

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3211,7 +3211,7 @@ indented the same amount."
 
 (defmacro markdown-temp-eww (&rest body)
   `(progn
-     ,@(if (fboundp 'eww-open-file) body
+     ,@(if (featurep 'eww) body
          `((ad-enable-advice #'markdown-live-preview-window-eww
                              'around 'markdown-create-fake-eww)
            (ad-activate #'markdown-live-preview-window-eww)
@@ -3222,7 +3222,7 @@ indented the same amount."
 
 (ert-deftest test-markdown-ext/live-preview-exports ()
   (markdown-test-temp-file "inline.text"
-    (unless (fboundp 'eww-open-file)
+    (unless (featurep 'eww)
       (should-error (markdown-live-preview-mode)))
     (markdown-temp-eww
      (markdown-live-preview-mode)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3211,7 +3211,7 @@ indented the same amount."
 
 (defmacro markdown-temp-eww (&rest body)
   `(progn
-     ,@(if (featurep 'eww) body
+     ,@(if (fboundp 'eww-open-file) body
          `((ad-enable-advice #'markdown-live-preview-window-eww
                              'around 'markdown-create-fake-eww)
            (ad-activate #'markdown-live-preview-window-eww)
@@ -3222,7 +3222,7 @@ indented the same amount."
 
 (ert-deftest test-markdown-ext/live-preview-exports ()
   (markdown-test-temp-file "inline.text"
-    (unless (featurep 'eww)
+    (unless (fboundp 'eww-open-file)
       (should-error (markdown-live-preview-mode)))
     (markdown-temp-eww
      (markdown-live-preview-mode)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3225,7 +3225,6 @@ indented the same amount."
     (unless (featurep 'eww)
       (should-error (markdown-live-preview-mode)))
     (markdown-temp-eww
-     (message "%s" "hey")
      (markdown-live-preview-mode)
      (should (buffer-live-p markdown-live-preview-buffer))
      (should (eq (current-buffer)


### PR DESCRIPTION
It makes more sense to check whether `'eww-open-file` is actually bound than all of `'eww`. Also, I left some test code in.