### PR TITLE
add async export

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3022,9 +3022,9 @@ header text is determined."
     ;; check prefix argument
     (cond
      ((and (equal arg '(4)) (> level 1)) ;; C-u
-      (decf level))
+      (cl-decf level))
      ((and (equal arg '(16)) (< level 6)) ;; C-u C-u
-      (incf level))
+      (cl-incf level))
      (arg ;; numeric prefix
       (setq level (prefix-numeric-value arg))))
     ;; setext headers must be level one or two
@@ -3226,7 +3226,7 @@ automatically in order to have the correct markup."
         (let ((fn (string-to-number (match-string 1))))
           (when (> fn markdown-footnote-counter)
             (setq markdown-footnote-counter fn))))))
-  (incf markdown-footnote-counter))
+  (cl-incf markdown-footnote-counter))
 
 (defun markdown-insert-footnote ()
   "Insert footnote with a new number and move point to footnote definition."
@@ -3261,7 +3261,7 @@ footnote marker or in the footnote text."
       ;; We're starting in footnote text, so mark our return position and jump
       ;; to the marker if possible.
       (let ((marker-pos (markdown-footnote-find-marker
-                         (first starting-footnote-text-positions))))
+                         (cl-first starting-footnote-text-positions))))
             (if marker-pos
                 (goto-char (1- marker-pos))
               ;; If there isn't a marker, we still want to kill the text.
@@ -3275,10 +3275,10 @@ footnote marker or in the footnote text."
           (error "Not at a footnote"))
         ;; Even if we knew the text position before, it changed when we deleted
         ;; the label.
-        (setq marker-pos (second marker))
-        (let ((new-text-pos (markdown-footnote-find-text (first marker))))
+        (setq marker-pos (cl-second marker))
+        (let ((new-text-pos (markdown-footnote-find-text (cl-first marker))))
           (unless new-text-pos
-            (error "No text for footnote `%s'" (first marker)))
+            (error "No text for footnote `%s'" (cl-first marker)))
           (goto-char new-text-pos))))
     (let ((pos (markdown-footnote-kill-text)))
       (goto-char (if starting-footnote-text-positions
@@ -3292,7 +3292,7 @@ start position of the marker before deletion.  If no footnote
 marker was deleted, this function returns NIL."
   (let ((marker (markdown-footnote-marker-positions)))
     (when marker
-      (delete-region (second marker) (third marker))
+      (delete-region (cl-second marker) (cl-third marker))
       (butlast marker))))
 
 (defun markdown-footnote-kill-text ()
@@ -3304,14 +3304,14 @@ The killed text is placed in the kill ring (without the footnote
 number)."
   (let ((fn (markdown-footnote-text-positions)))
     (when fn
-      (let ((text (delete-and-extract-region (second fn) (third fn))))
-        (string-match (concat "\\[\\" (first fn) "\\]:[[:space:]]*\\(\\(.*\n?\\)*\\)") text)
+      (let ((text (delete-and-extract-region (cl-second fn) (cl-third fn))))
+        (string-match (concat "\\[\\" (cl-first fn) "\\]:[[:space:]]*\\(\\(.*\n?\\)*\\)") text)
         (kill-new (match-string 1 text))
         (when (and (markdown-cur-line-blank-p)
                    (markdown-prev-line-blank-p)
                    (not (bobp)))
           (delete-region (1- (point)) (point)))
-        (second fn)))))
+        (cl-second fn)))))
 
 (defun markdown-footnote-goto-text ()
   "Jump to the text of the footnote at point."
@@ -3482,7 +3482,7 @@ text to kill ring), and list items."
       (delete-region (match-beginning 0) (match-end 0)))
      ;; List item
      ((setq val (markdown-cur-list-item-bounds))
-      (kill-new (delete-and-extract-region (first val) (second val))))
+      (kill-new (delete-and-extract-region (cl-first val) (cl-second val))))
      (t
       (error "Nothing found at point to kill")))))
 
@@ -4265,9 +4265,9 @@ as by `markdown-get-undefined-refs'."
   "Insert a button for jumping to LINK in buffer OLDBUF.
 LINK should be a list of the form (text char line) containing
 the link text, location, and line number."
-  (let ((label (first link))
-        (char (second link))
-        (line (third link)))
+  (let ((label (cl-first link))
+        (char (cl-second link))
+        (line (cl-third link)))
     (if (markdown-use-buttons-p)
         ;; Create a reference button in Emacs 22
         (insert-button label
@@ -5098,7 +5098,7 @@ Return the name of the output buffer used."
         (buffer-disable-undo))
       (if markdown-command-needs-filename
           (markdown-process-file output-buffer-name callback)
-        (destructuring-bind (beg end) (markdown-get-active-region)
+        (cl-destructuring-bind (beg end) (markdown-get-active-region)
           (markdown-process-region beg end output-buffer-name callback))))))
 
 (defun markdown-standalone (&optional output-buffer-name callback)
@@ -5274,7 +5274,7 @@ non-nil."
 (defun markdown-live-preview-window-deserialize (window-posns)
   "Apply window point and scroll data from WINDOW-POSNS, given by
 `markdown-live-preview-window-serialize'."
-  (destructuring-bind (win pt start) window-posns
+  (cl-destructuring-bind (win pt start) window-posns
     (when (window-live-p win)
       (set-window-buffer win markdown-live-preview-buffer)
       (set-window-point win pt)
@@ -5484,7 +5484,7 @@ and [[test test]] both map to Test-test.ext."
                                 (file-name-extension (buffer-file-name))))))
            (current default))
       (catch 'done
-        (loop
+        (cl-loop
          (if (or (file-exists-p current)
                  (not markdown-wiki-link-search-parent-directories))
              (throw 'done current))
@@ -5560,7 +5560,7 @@ newline after."
     (re-search-forward "\n" nil t)
     (if (not (= (point) to))
         (setq new-to (point)))
-    (values new-from new-to)))
+    (cl-values new-from new-to)))
 
 (defun markdown-check-change-for-wiki-link (from to _change)
   "Check region between FROM and TO for wiki links and re-fontfy as needed.
@@ -5580,7 +5580,7 @@ given range."
              (save-restriction
                ;; Extend the region to fontify so that it starts
                ;; and ends at safe places.
-               (multiple-value-bind (new-from new-to)
+               (cl-multiple-value-bind (new-from new-to)
                    (markdown-extend-changed-region from to)
                  (goto-char new-from)
                  ;; Only refontify when the range contains text with a

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -31,6 +31,7 @@
 ;; Maintainer: Jason R. Blevins <jrblevin@sdf.org>
 ;; Created: May 24, 2007
 ;; Version: 2.0
+;; Package-Requires: ((cl-lib "0.5"))
 ;; Keywords: Markdown, GitHub Flavored Markdown, itex
 ;; URL: http://jblevins.org/projects/markdown-mode/
 
@@ -842,7 +843,7 @@
 (require 'easymenu)
 (require 'outline)
 (require 'thingatpt)
-(eval-when-compile (require 'cl))
+(require 'cl-lib)
 
 (declare-function eww-open-file "eww")
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2314,7 +2314,7 @@ intact additional processing."
     (let (refs)
       (while (re-search-forward markdown-regex-reference-definition nil t)
         (let ((target (match-string-no-properties 2)))
-          (pushnew target refs :test #'equal)))
+          (cl-pushnew target refs :test #'equal)))
       (reverse refs))))
 
 (defun markdown-code-at-point-p ()
@@ -3757,7 +3757,7 @@ match."
                   (or match (setq match (looking-back prev-regexp nil)))))
               (unless match
                 (save-excursion (funcall function))))))
-        (pushnew regexp previous :test #'equal)))))
+        (cl-pushnew regexp previous :test #'equal)))))
 
 (defun markdown-complete-buffer ()
   "Complete markup for all objects in the current buffer."
@@ -4123,7 +4123,7 @@ the link, and line is the line number on which the link appears."
                          (match-string-no-properties 2)))
                (start (match-beginning 0))
                (line (markdown-line-number-at-pos)))
-          (pushnew (list text start line) links :test #'equal))))
+          (cl-pushnew (list text start line) links :test #'equal))))
     links))
 
 (defun markdown-get-undefined-refs ()
@@ -4144,7 +4144,7 @@ For example, an alist corresponding to [Nice editor][Emacs] at line 12,
           (unless (markdown-reference-definition target)
             (let ((entry (assoc target missing)))
               (if (not entry)
-                  (pushnew
+                  (cl-pushnew
                    (cons target
                          (list (cons text (markdown-line-number-at-pos))))
                    missing)
@@ -4987,13 +4987,13 @@ output buffer name as the result of PROC-OR-OUTPUT-FILE-EXPR.
 `markdown-make-process-sentinel', as well as all users of this macro, do this
 correctly."
   (declare (indent 3))
-  (let ((proc-sentinel (gensym))
-        (cur-buf (gensym))
-        (proc (gensym))
-        (new-proc-sentinel (gensym))
-        (proc-arg (gensym))
-        (msg-arg (gensym))
-        (result (gensym)))
+  (let ((proc-sentinel (cl-gensym))
+        (cur-buf (cl-gensym))
+        (proc (cl-gensym))
+        (new-proc-sentinel (cl-gensym))
+        (proc-arg (cl-gensym))
+        (msg-arg (cl-gensym))
+        (result (cl-gensym)))
     `(if ,asyncp
          (let ((,cur-buf (current-buffer))
                (,proc ,proc-or-output-file-expr))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5347,8 +5347,7 @@ the rendered output."
              markdown-live-preview-mode)
     (if markdown-live-preview-currently-exporting
         (setq markdown-live-preview-dirty-flag t)
-      (let ((live (buffer-live-p markdown-live-preview-buffer))
-            (cur-buf (current-buffer)))
+      (let ((live (buffer-live-p markdown-live-preview-buffer)))
         (markdown-do-sync-or-async markdown-export-async
             output-buf (markdown-live-preview-export markdown-export-async)
           (unless live (markdown-display-buffer-other-window output-buf)))))))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5304,6 +5304,11 @@ the rendered output."
                 (with-current-buffer cur-buf
                   (setq markdown-live-preview-buffer output-buffer))))
             (with-current-buffer cur-buf
+              ;; FIXME: when this is asynchronous, the user could have
+              ;; intentionally moved point or scrolled in any of the windows in
+              ;; between when the export begins and completes, and this wouldn't
+              ;; restore that.
+
               ;; reset all windows displaying output buffer to where they
               ;; were, now with the new output
               (mapc #'markdown-live-preview-window-deserialize window-data)))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2314,7 +2314,7 @@ intact additional processing."
     (let (refs)
       (while (re-search-forward markdown-regex-reference-definition nil t)
         (let ((target (match-string-no-properties 2)))
-          (cl-pushnew target refs :test #'equal)))
+          (pushnew target refs :test #'equal)))
       (reverse refs))))
 
 (defun markdown-code-at-point-p ()
@@ -3757,7 +3757,7 @@ match."
                   (or match (setq match (looking-back prev-regexp nil)))))
               (unless match
                 (save-excursion (funcall function))))))
-        (cl-pushnew regexp previous :test #'equal)))))
+        (pushnew regexp previous :test #'equal)))))
 
 (defun markdown-complete-buffer ()
   "Complete markup for all objects in the current buffer."
@@ -4123,7 +4123,7 @@ the link, and line is the line number on which the link appears."
                          (match-string-no-properties 2)))
                (start (match-beginning 0))
                (line (markdown-line-number-at-pos)))
-          (cl-pushnew (list text start line) links :test #'equal))))
+          (pushnew (list text start line) links :test #'equal))))
     links))
 
 (defun markdown-get-undefined-refs ()
@@ -4144,7 +4144,7 @@ For example, an alist corresponding to [Nice editor][Emacs] at line 12,
           (unless (markdown-reference-definition target)
             (let ((entry (assoc target missing)))
               (if (not entry)
-                  (cl-pushnew
+                  (pushnew
                    (cons target
                          (list (cons text (markdown-line-number-at-pos))))
                    missing)
@@ -4987,13 +4987,13 @@ output buffer name as the result of PROC-OR-OUTPUT-FILE-EXPR.
 `markdown-make-process-sentinel', as well as all users of this macro, do this
 correctly."
   (declare (indent 3))
-  (let ((proc-sentinel (cl-gensym))
-        (cur-buf (cl-gensym))
-        (proc (cl-gensym))
-        (new-proc-sentinel (cl-gensym))
-        (proc-arg (cl-gensym))
-        (msg-arg (cl-gensym))
-        (result (cl-gensym)))
+  (let ((proc-sentinel (gensym))
+        (cur-buf (gensym))
+        (proc (gensym))
+        (new-proc-sentinel (gensym))
+        (proc-arg (gensym))
+        (msg-arg (gensym))
+        (result (gensym)))
     `(if ,asyncp
          (let ((,cur-buf (current-buffer))
                (,proc ,proc-or-output-file-expr))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5224,6 +5224,12 @@ current filename, but with the extension removed and replaced with .html."
         (with-current-buffer output-buffer-name
           (run-hooks 'markdown-after-export-hook)
           (save-buffer))
+        ;; if modified, restore initial buffer
+        (when (buffer-modified-p init-buf)
+          (erase-buffer)
+          (insert init-buf-string)
+          (save-buffer)
+          (goto-char init-point))
         output-file))))
 
 (defun markdown-export-and-preview ()

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -1538,7 +1538,7 @@ the opening bracket of [^2], and then subsequent functions would kill [^2])."
                         ;; really overly broad.)
                         (should (string-equal
                                  "Cannot move past superior level"
-                                 (second (should-error (markdown-move-subtree-up)))))))
+                                 (cl-second (should-error (markdown-move-subtree-up)))))))
 
 (ert-deftest test-markdown-subtree/move-down ()
   "Test `markdown-move-subtree-down'."
@@ -2442,7 +2442,7 @@ returns nil."
   (markdown-test-file "nested-list.text"
    (let ((values '(((1 . 1) . nil) ((2 . 13) . (3)) ((14 . 23) . (7 3))
                    ((24 . 26) . (11 7 3)))))
-     (loop for (range . value) in values
+     (cl-loop for (range . value) in values
            do (goto-char (point-min))
               (forward-line (1- (car range)))
               (dotimes (n (- (cdr range) (car range)))
@@ -2457,7 +2457,7 @@ returns nil."
                    ((26 . 29) . (4 0)) ((30 . 30) . (0)) ((31 . 33) . (4 0))
                    ((34 . 588) . nil) ((589 . 595) . (0)) ((596 . 814) . nil)
                    ((815 . 820) . (0)) ((821 . 898) . nil))))
-     (loop for (range . value) in values
+     (cl-loop for (range . value) in values
            do (goto-char (point-min))
               (forward-line (1- (car range)))
               (dotimes (n (- (cdr range) (car range)))


### PR DESCRIPTION
This is more of a WIP than a completed feature; it needs a bit (a lot) more documentation/testing (any testing)/refactoring. Basically, it adds a defcustom `markdown-export-async`, which, if non-nil, performs the export operation in an asynchronous subprocess. This is nice because it pauses a lot less when the user saves while working, especially for larger files.

This is done without duplicating all the export code for sync and async by replacing all calls to `markdown` (and all functions that call those functions which call `markdown`, etc) with use of the `markdown-do-sync-or-async` macro, which performs the normal synchronous operation if `asyncp` is nil, but creates a lambda which attaches to the process sentinel otherwise (which is the reason for the `lexical-binding: t;`, or sets its result to `markdown-async-result` if the process finished.

Once the `lexical-binding: t;` was added, I worked to fix some of the byte compiler errors. I would recommend taking a look at b5eb8cb closely; I did my best to fix what was obvious but I may have done something silly due to lack of familiarity with the code.

The default callback for the async export (set in `markdown-make-process-sentinel`) is to message the user saying it completed; I'm considering making that a defcustom as well, or just a boolean for whether or not to message the user at all.

I'll be working on this more, and I know I already have a pr up, so don't worry about getting to this super fast.