### PR TITLE
fix #59

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3285,18 +3285,8 @@ already in `markdown-gfm-recognized-languages' or
          (find-result
           (cl-find cleaned-lang (markdown-gfm-get-corpus)
                    :test #'equal)))
-    (if find-result (setq markdown-gfm-last-used-language find-result)
-      ;; we have already checked whether it exists in the list using our fuzzy
-      ;; `markdown-compare-language-strings' function, so we can just push
-      (push cleaned-lang markdown-gfm-used-languages)
-      (setq markdown-gfm-last-used-language cleaned-lang))))
-
-(defun markdown-parse-gfm-buffer-for-languages (&optional buffer)
-  (with-current-buffer (or buffer (current-buffer))
-    (save-excursion
-      (goto-char (point-min))
-      (while (re-search-forward markdown-regex-gfm-code-block nil t)
-        (markdown-add-language-if-new (match-string-no-properties 2))))))
+    (setq markdown-gfm-last-used-language cleaned-lang)
+    (unless find-result (push cleaned-lang markdown-gfm-used-languages))))
 
 (defun markdown-insert-gfm-code-block (&optional lang)
   "Insert GFM code block for language LANG.
@@ -3340,6 +3330,13 @@ automatically in order to have the correct markup."
     (insert "```")
     (markdown-ensure-blank-line-after)
     (forward-line -1)))
+
+(defun markdown-gfm-parse-buffer-for-languages (&optional buffer)
+  (with-current-buffer (or buffer (current-buffer))
+    (save-excursion
+      (goto-char (point-min))
+      (while (re-search-forward markdown-regex-gfm-code-block nil t)
+        (markdown-add-language-if-new (match-string-no-properties 2))))))
 
 
 ;;; Footnotes ======================================================================
@@ -5948,7 +5945,7 @@ before regenerating font-lock rules for extensions."
        '(gfm-font-lock-keywords))
   ;; do the initial link fontification
   (markdown-fontify-buffer-wiki-links)
-  (markdown-parse-gfm-buffer-for-languages))
+  (markdown-gfm-parse-buffer-for-languages))
 
 
 ;;; Live Preview Mode  ============================================

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3274,20 +3274,13 @@ already in `markdown-gfm-recognized-languages' or
       (widget-put widget :error (format "Invalid language spec: '%s'" str))
       widget)))
 
-(defun markdown-compare-language-strings (str1 str2)
-  ;; note that this keeps the first capitalization of a language used in a
-  ;; buffer
-  ;; this also relies upon the fact that all input strings have been cleaned
-  ;; with `markdown-clean-language-string'
-  (eq t (compare-strings str1 nil nil str2 nil nil t)))
-
 (defun markdown-add-language-if-new (lang)
   (let* ((cleaned-lang (markdown-clean-language-string lang))
          (find-result
           (cl-find cleaned-lang (append markdown-gfm-used-languages
                                         markdown-gfm-additional-languages
                                         markdown-gfm-recognized-languages)
-                   :test #'markdown-compare-language-strings)))
+                   :test #'equal)))
     (if find-result (setq markdown-gfm-last-used-language find-result)
       ;; we have already checked whether it exists in the list using our fuzzy
       ;; `markdown-compare-language-strings' function, so we can just push
@@ -3308,7 +3301,7 @@ region is active, wrap this region with the markup instead.  If
 the region boundaries are not on empty lines, these are added
 automatically in order to have the correct markup."
   (interactive
-   (list (let ((completion-ignore-case t))
+   (list (let ((completion-ignore-case nil))
            (markdown-clean-language-string
             (completing-read
              (format "Programming language [%s]: "

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3274,12 +3274,16 @@ already in `markdown-gfm-recognized-languages' or
       (widget-put widget :error (format "Invalid language spec: '%s'" str))
       widget)))
 
+(defun markdown-gfm-get-corpus ()
+  "Create corpus of recognized GFM code block languages for the given buffer."
+  (append markdown-gfm-used-languages
+          markdown-gfm-additional-languages
+          markdown-gfm-recognized-languages))
+
 (defun markdown-add-language-if-new (lang)
   (let* ((cleaned-lang (markdown-clean-language-string lang))
          (find-result
-          (cl-find cleaned-lang (append markdown-gfm-used-languages
-                                        markdown-gfm-additional-languages
-                                        markdown-gfm-recognized-languages)
+          (cl-find cleaned-lang (markdown-gfm-get-corpus)
                    :test #'equal)))
     (if find-result (setq markdown-gfm-last-used-language find-result)
       ;; we have already checked whether it exists in the list using our fuzzy
@@ -3306,9 +3310,7 @@ automatically in order to have the correct markup."
             (completing-read
              (format "Programming language [%s]: "
                      (or markdown-gfm-last-used-language "none"))
-             (append markdown-gfm-used-languages
-                     markdown-gfm-additional-languages
-                     markdown-gfm-recognized-languages)
+             (markdown-gfm-get-corpus)
              nil 'confirm nil
              'markdown-gfm-language-history
              (or markdown-gfm-last-used-language

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3155,16 +3155,16 @@ indented the same amount."
    (should (string-equal (buffer-string)
                          "line 1\n\n``` elisp\nline 2\n```\n\nline 3\n"))))
 
-(ert-deftest test-markdown-gfm/parse-gfm-buffer-for-languages ()
+(ert-deftest test-markdown-gfm/gfm-parse-buffer-for-languages ()
   "Parse buffer for existing languages for `markdown-gfm-used-languages' test."
-  (markdown-test-string-gfm "``` MADEUP\n\n```\n```LANGUAGES\n\n```\n"
-    (markdown-parse-gfm-buffer-for-languages)
-    (should (equal markdown-gfm-used-languages (list "LANGUAGES" "MADEUP")))
-    (should (equal markdown-gfm-last-used-language "LANGUAGES"))
+  (markdown-test-string-gfm "``` MADEUP\n\n```\n```LANGUAGES\n\n```\n```MaDeUp\n\n```\n"
+    (markdown-gfm-parse-buffer-for-languages)
+    (should (equal markdown-gfm-used-languages (list "MaDeUp" "LANGUAGES" "MADEUP")))
+    (should (equal markdown-gfm-last-used-language "MaDeUp"))
     (goto-char (point-max))
     (markdown-insert-gfm-code-block "newlang")
     (should (equal markdown-gfm-used-languages
-                   (list "newlang" "LANGUAGES" "MADEUP")))
+                   (list "newlang" "MaDeUp" "LANGUAGES" "MADEUP")))
     (should (equal markdown-gfm-last-used-language "newlang"))))
 
 (ert-deftest test-markdown-gfm/code-block-font-lock ()


### PR DESCRIPTION
If a user enters a language using `markdown-insert-gfm-code-block`, or it exists in the buffer when `markdown-parse-gfm-buffer-for-languages` is called, and the language has different capitalization than one already in the corpus, it will prompt for confirmation (if done interactively), and then add it to the buffer-local corpus, and insert the language literally as the user gave it.