### PR TITLE
don't add global hooks for live-preview

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5314,7 +5314,9 @@ the rendered output."
       (let ((output-buffer
              (funcall markdown-live-preview-window-function export-file)))
         (with-current-buffer output-buffer
-          (setq markdown-live-preview-source-buffer cur-buf))
+          (setq markdown-live-preview-source-buffer cur-buf)
+          (add-hook 'kill-buffer-hook
+                    #'markdown-live-preview-remove-on-kill t t))
         (with-current-buffer cur-buf
           (setq markdown-live-preview-buffer output-buffer))))
     (with-current-buffer cur-buf
@@ -5912,6 +5914,7 @@ before regenerating font-lock rules for extensions."
 
   ;; add live preview export hook
   (add-hook 'after-save-hook #'markdown-live-preview-if-markdown t t)
+  (add-hook 'kill-buffer-hook #'markdown-live-preview-remove-on-kill t t)
 
   ;; do the initial link fontification
   (markdown-fontify-buffer-wiki-links))
@@ -5958,8 +5961,6 @@ before regenerating font-lock rules for extensions."
   (if markdown-live-preview-mode
       (markdown-display-buffer-other-window (markdown-live-preview-export))
     (markdown-live-preview-remove)))
-
-(add-hook 'kill-buffer-hook #'markdown-live-preview-remove-on-kill t)
 
 
 (provide 'markdown-mode)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5910,6 +5910,9 @@ before regenerating font-lock rules for extensions."
   (add-hook 'window-configuration-change-hook
             'markdown-fontify-buffer-wiki-links t t)
 
+  ;; add live preview export hook
+  (add-hook 'after-save-hook #'markdown-live-preview-if-markdown t t)
+
   ;; do the initial link fontification
   (markdown-fontify-buffer-wiki-links))
 
@@ -5956,8 +5959,7 @@ before regenerating font-lock rules for extensions."
       (markdown-display-buffer-other-window (markdown-live-preview-export))
     (markdown-live-preview-remove)))
 
-(add-hook 'after-save-hook #'markdown-live-preview-if-markdown)
-(add-hook 'kill-buffer-hook #'markdown-live-preview-remove-on-kill)
+(add-hook 'kill-buffer-hook #'markdown-live-preview-remove-on-kill t)
 
 
 (provide 'markdown-mode)


### PR DESCRIPTION
Take global hooks and make them buffer-local. `markdown-live-preview-remove-on-kill` applies to both the markdown buffers and the buffers used to preview the export, so it needs to be re-added in two places, where the export-viewing buffer is created, and when `markdown-mode` is turned on.

The test `test-markdown-ext/live-preview-exports` adequately covers whether these hooks run.