### PR TITLE
fix case when no language given for suggesting gfm code block langs

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3336,7 +3336,8 @@ automatically in order to have the correct markup."
     (save-excursion
       (goto-char (point-min))
       (while (re-search-forward markdown-regex-gfm-code-block nil t)
-        (markdown-add-language-if-new (match-string-no-properties 2))))))
+        (let ((lang (match-string-no-properties 2)))
+          (when lang (markdown-add-language-if-new lang)))))))
 
 
 ;;; Footnotes ======================================================================

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3293,16 +3293,18 @@ the region boundaries are not on empty lines, these are added
 automatically in order to have the correct markup."
   (interactive
    (list (let ((completion-ignore-case nil))
-           (markdown-clean-language-string
-            (completing-read
-             (format "Programming language [%s]: "
-                     (or markdown-gfm-last-used-language "none"))
-             (markdown-gfm-get-corpus)
-             nil 'confirm nil
-             'markdown-gfm-language-history
-             (or markdown-gfm-last-used-language
-                 (car markdown-gfm-additional-languages)))))))
-  (markdown-add-language-if-new lang)
+           (condition-case _err
+               (markdown-clean-language-string
+                (completing-read
+                 (format "Programming language [%s]: "
+                         (or markdown-gfm-last-used-language "none"))
+                 (markdown-gfm-get-corpus)
+                 nil 'confirm nil
+                 'markdown-gfm-language-history
+                 (or markdown-gfm-last-used-language
+                     (car markdown-gfm-additional-languages))))
+             (quit "")))))
+  (unless (string= lang "") (markdown-add-language-if-new lang))
   (when (> (length lang) 0) (setq lang (concat " " lang)))
   (if (markdown-use-region-p)
       (let ((b (region-beginning)) (e (region-end)))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1218,13 +1218,10 @@ Group 2 matches the key sequence.")
 
 (defconst markdown-regex-gfm-code-block
   (concat
-   "^\\s *\\(```\\)[ ]?\\([^[:space:]]+\\|{[^}]*}\\)?"
+   "^\\s *\\(```\\)[ ]*\\([^[:space:]]+\\|{[^}]*}\\)?"
    "[[:space:]]*?\n"
    "\\(\\(?:.\\|\n\\)*?\\)?"
-   ;; the newline before the final line could have a ?, but then it gets mixed
-   ;; up with `markdown-regex-code'. this way, there always needs to be at least
-   ;; two newlines between the pair of triple backticks
-   "\n\\s *?\\(```\\)\\s *?$")
+   "\n?\\s *?\\(```\\)\\s *?$")
  "Regular expression matching opening of GFM code blocks.
 Group 1 matches the opening three backticks.
 Group 2 matches the language identifier (optional).

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3157,9 +3157,10 @@ indented the same amount."
 
 (ert-deftest test-markdown-gfm/gfm-parse-buffer-for-languages ()
   "Parse buffer for existing languages for `markdown-gfm-used-languages' test."
-  (markdown-test-string-gfm "``` MADEUP\n\n```\n```LANGUAGES\n\n```\n```MaDeUp\n\n```\n"
+  (markdown-test-string-gfm "``` MADEUP\n\n```\n``` LANGUAGES\n\n```\n```MaDeUp\n\n```\n```\n\n```\n``` \n\n```\n"
     (markdown-gfm-parse-buffer-for-languages)
-    (should (equal markdown-gfm-used-languages (list "MaDeUp" "LANGUAGES" "MADEUP")))
+    (should (equal markdown-gfm-used-languages
+                   (list "MaDeUp" "LANGUAGES" "MADEUP")))
     (should (equal markdown-gfm-last-used-language "MaDeUp"))
     (goto-char (point-max))
     (markdown-insert-gfm-code-block "newlang")


### PR DESCRIPTION
Three things:

1. Previously, if no language was given for a gfm code block (so just three backticks open/close), `markdown-gfm-parse-buffer-for-languages` would error out because the `(match-string-no-properties 2)` call would return nil. This fixes that.
2. Adds a `?` to the second newline in a block, allowing empty code blocks (which github allows).
3. Allows using <kbd>C-g</kbd> to quit out of the `completing-read` for a language, and returns an empty string, so you can create code blocks with no specified language without having to backspace.