### PR TITLE
Safer convert to filename

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5489,14 +5489,16 @@ and [[test test]] both map to Test-test.ext."
                                 (file-name-extension (buffer-file-name))))))
            (current default))
       (catch 'done
-        (cl-loop
-         (if (or (file-exists-p current)
-                 (not markdown-wiki-link-search-parent-directories))
-             (throw 'done current))
-         (if (string-equal (expand-file-name current)
-                           (concat "/" default))
-             (throw 'done default))
-         (setq current (concat "../" current)))))))
+        (condition-case nil
+            (cl-loop
+             (if (or (not markdown-wiki-link-search-parent-directories)
+                     (file-exists-p current))
+                 (throw 'done current))
+             (if (string-equal (expand-file-name current)
+                               (concat "/" default))
+                 (throw 'done default))
+             (setq current (concat "../" current)))
+          (error default))))))
 
 (defun markdown-follow-wiki-link (name &optional other)
   "Follow the wiki link NAME.

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5545,7 +5545,7 @@ and highlight accordingly."
               (file-name
                (markdown-convert-wiki-link-to-filename
                 (markdown-wiki-link-link))))
-          (if (file-exists-p file-name)
+          (if (condition-case nil (file-exists-p file-name) (error nil))
               (markdown-highlight-wiki-link
                highlight-beginning highlight-end markdown-link-face)
             (markdown-highlight-wiki-link


### PR DESCRIPTION
With sufficiently evil contents in [[Wikilinks]], it's possible to confuse emacs and tramp to the point that they won't let you switch away from the buffer.  Handle conditions appropriately when examining the filesystem for
files named by wikilink content.