### PR TITLE
Fix issue67

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2433,6 +2433,15 @@ Return nil otherwise."
                           (match-beginning 5) (match-end 5)))
     (goto-char (1+ (match-end 0)))))
 
+(defun markdown-list-p (pos)
+  (save-excursion
+    (goto-char pos)
+    (goto-char (line-beginning-position))
+    (looking-at-p markdown-regex-list)))
+
+(defun markdown-same-line-p (pos1 pos2)
+  (= (markdown-line-number-at-pos pos1) (markdown-line-number-at-pos pos2)))
+
 (defun markdown-match-italic (last)
   "Match inline italics from the point to LAST."
   (let ((regex (if (eq major-mode 'gfm-mode)
@@ -2446,7 +2455,8 @@ Return nil otherwise."
                                  markdown-math-face))
           (goto-char (1+ (match-end 0)))
           (markdown-match-italic last))
-         (t
+         ((or (markdown-same-line-p begin end)
+              (not (or (markdown-list-p begin) (markdown-list-p end))))
           (set-match-data (list (match-beginning 1) (match-end 1)
                                 (match-beginning 2) (match-end 2)
                                 (match-beginning 3) (match-end 3)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -1743,12 +1743,22 @@ the opening bracket of [^2], and then subsequent functions would kill [^2])."
 
 (ert-deftest test-markdown-font-lock/italics-6 ()
   "Test multiline italics across list items."
-  :expected-result :failed
   (markdown-test-string
    "* something about function foo_bar
 * something else about foo_bar"
    (markdown-test-range-has-face 31 34 nil)
-   (markdown-test-range-has-face 38 62 nil)))
+   (markdown-test-range-has-face 38 62 nil))
+  (markdown-test-string
+   "foo_bar
+* foo_bar"
+   (markdown-test-range-has-face 4 7 nil)
+   (markdown-test-range-has-face 11 14 nil))
+
+  (markdown-test-string
+   "* foo_bar
+foo_bar"
+   (markdown-test-range-has-face 6 9 nil)
+   (markdown-test-range-has-face 11 14 nil)))
 
 (ert-deftest test-markdown-font-lock/italics-after-hr ()
   "Test italics after a horizontal rule with asterisks."


### PR DESCRIPTION
Highlight italic only following cases
- Italic start and end point are same line
- If italic start and end point are different line, both lines are not list

#### Original

![orig](https://cloud.githubusercontent.com/assets/554281/12219965/6a839bc6-b79d-11e5-9659-7bda915a3ab1.png)

#### Fixed version

![fixed](https://cloud.githubusercontent.com/assets/554281/12219967/71056baa-b79d-11e5-8db6-9cf172dd659b.png)

This is related to #67.
CC: @hmelman