### PR TITLE
Don't insert empty titles

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2909,7 +2909,7 @@ be used to populate the title attribute when converted to XHTML."
         (insert url)
       ;; When no URL is given, leave cursor at END following the colon
       (setq end (point)))
-    (when (and title (> (length title) 0))
+    (when (> (length title) 0)
       (insert " \"" title "\""))
     (unless (looking-at "\n")
       (insert "\n"))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2909,7 +2909,7 @@ be used to populate the title attribute when converted to XHTML."
         (insert url)
       ;; When no URL is given, leave cursor at END following the colon
       (setq end (point)))
-    (when title
+    (when (and title (> (length title) 0))
       (insert " \"" title "\""))
     (unless (looking-at "\n")
       (insert "\n"))


### PR DESCRIPTION
Guard against `title` being an empty string.  There's no use in inserting empty titles, or did I miss something?