### PR TITLE
add outline-minor-mode with markdown headings

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -6072,7 +6072,9 @@ before regenerating font-lock rules for extensions."
   (add-hook 'kill-buffer-hook #'markdown-live-preview-remove-on-kill t t)
 
   ;; do the initial link fontification
-  (markdown-fontify-buffer-wiki-links))
+  (markdown-fontify-buffer-wiki-links)
+  ;; add `outline-minor-mode' for free section hiding
+  (outline-minor-mode 1))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.markdown\\'" . markdown-mode))


### PR DESCRIPTION
`outline-minor-mode` allows traversing and folding headings, just like the `outline-mode` major mode. The keybindings don't conflict with any bindings already in `markdown-mode`, and allow folding just like `org-mode`. I couldn't think of what tests would be appropriate since this just adds the functionality `outline-minor-mode` already does, but I can definitely add some as required.

To play with it, just open a markdown file and try <kbd>C-c @ C-c</kbd> to hide, and <kbd>C-c @ C-e</kbd> to show a heading. There are more complex controls too, all the same as in `outline-mode`.