### PR TITLE
Specify minimum Emacs version

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -32,7 +32,7 @@
 ;; Maintainer: Jason R. Blevins <jrblevin@sdf.org>
 ;; Created: May 24, 2007
 ;; Version: 2.1
-;; Package-Requires: ((cl-lib "0.5"))
+;; Package-Requires: ((emacs "24") (cl-lib "0.5"))
 ;; Keywords: Markdown, GitHub Flavored Markdown, itex
 ;; URL: http://jblevins.org/projects/markdown-mode/
 


### PR DESCRIPTION
lexical-bindings was introduced since Emacs 24.