### PR TITLE
Save match data in markdown-syntax-propertize-extend-region

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1455,19 +1455,20 @@ This helps improve syntax analysis for block constructs.
 Returns a cons (NEW-START . NEW-END) or nil if no adjustment should be made.
 Function is called repeatedly until it returns nil. For details, see
 `syntax-propertize-extend-region-functions'."
-  (save-excursion
-    (let* ((new-start (progn (goto-char start)
-                             (if (re-search-backward "\n\n" nil t)
-                                 (match-end 0) (point-min))))
-           (new-end (progn (goto-char end)
-                           (if (re-search-forward "\n\n" nil t)
-                               (match-beginning 0) (point-max))))
-           (code-match (markdown-code-block-at-pos new-start))
-           (new-start (or (and code-match (cl-first code-match)) new-start))
-           (code-match (markdown-code-block-at-pos end))
-           (new-end (or (and code-match (cl-second code-match)) new-end)))
-      (unless (and (eq new-start start) (eq new-end end))
-        (cons new-start new-end)))))
+  (save-match-data
+    (save-excursion
+      (let* ((new-start (progn (goto-char start)
+                               (if (re-search-backward "\n\n" nil t)
+                                   (match-end 0) (point-min))))
+             (new-end (progn (goto-char end)
+                             (if (re-search-forward "\n\n" nil t)
+                                 (match-beginning 0) (point-max))))
+             (code-match (markdown-code-block-at-pos new-start))
+             (new-start (or (and code-match (cl-first code-match)) new-start))
+             (code-match (markdown-code-block-at-pos end))
+             (new-end (or (and code-match (cl-second code-match)) new-end)))
+        (unless (and (eq new-start start) (eq new-end end))
+          (cons new-start new-end))))))
 
 (defun markdown-font-lock-extend-region-function (start end _)
   "Used in `jit-lock-after-change-extend-region-functions'. Delegates to


### PR DESCRIPTION
This function should not overwrite match data.

I suppose this is related to following issues

- https://github.com/jrblevin/markdown-mode/issues/104
- https://github.com/syl20bnr/spacemacs/issues/5203

