### PR TITLE
Check whether markdown-command is installed

### DIFF
--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3782,8 +3782,10 @@ Detail: https://github.com/jrblevin/markdown-mode/issues/79"
            (ad-activate #'markdown-live-preview-window-eww)))))
 
 (defmacro markdown-test-eww-or-nothing (test &rest body)
-  (if (and (fboundp 'libxml-parse-html-region) (require 'eww nil t)) `(progn ,@body)
-    (message "no eww, or no libxml2 found: skipping %s" test)
+  (if (and (fboundp 'libxml-parse-html-region) (require 'eww nil t)
+           (executable-find markdown-command))
+      `(progn ,@body)
+    (message "no eww, no libxml2, or no %s found: skipping %s" markdown-command test)
     nil))
 
 (ert-deftest test-markdown-ext/live-preview-exports ()


### PR DESCRIPTION
Markdown is not rendered if markdown-command is not installed. This causes unexpected test failure. Tests which are introduced at #102 are failed if `markdown-command`(Default value is `markdown`) is not installed. Body should not be evaluated if the command is not installed.

For example,  test is failed if `markdown` is not installed because buffer content is not HTML and is `bash: markdown is not found` instead.
```
Test test-markdown-ext/live-preview-follow-min-max condition:
    (ert-test-failed
     ((should
       (=
        (window-point)
        (+ final-pt ...)))
      :form
      (= 36 44)
      :value nil))
```

CC: @cosmicexplorer