### PR TITLE
Respect narrowed region in markdown-find-previous-prop

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1602,7 +1602,7 @@ of (pos . property). pos is point if point contains non-nil PROP."
            (previous-single-property-change
             (point) prop nil (or lim (point-min))))))
     (when (and (not (get-text-property res prop))
-               (> res 1)
+               (> res (point-min))
                (get-text-property (1- res) prop))
       (cl-decf res))
     (when (and res (get-text-property res prop)) (cons res prop))))


### PR DESCRIPTION
Hi, 

In multi-modes like [`polymode`](https://github.com/vspinu/polymode) all `markdown-mode` functionality like font-locking and syntax properties is executed in narrowed regions. 

It would be great if the code would not rely on assumptions like buffer starting at 1. This is a fix of one of such issues, there might be others. I will report if I find more.  
