### PR TITLE
Inflloop in font-lock due to mismatched cache

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2891,13 +2891,17 @@ Return nil otherwise."
 (defun markdown-match-propertized-text (property last)
   "Match text with PROPERTY from point to LAST.
 Restore match data previously stored in PROPERTY."
-  (let (saved pos)
-    (unless (setq saved (get-text-property (point) property))
+  (let ((saved (get-text-property (point) property))
+        pos)
+    (unless saved
       (setq pos (next-single-char-property-change (point) property nil last))
       (setq saved (get-text-property pos property)))
     (when saved
       (set-match-data saved)
-      (goto-char (min (1+ (match-end 0)) (point-max)))
+      ;; Step at least one character beyond point. Otherwise
+      ;; `font-lock-fontify-keywords-region' infloops.
+      (goto-char (min (1+ (max (match-end 0) (point)))
+                      (point-max)))
       saved)))
 
 (defun markdown-match-pre-blocks (last)


### PR DESCRIPTION
I have got an infloop report from multiple users (vspinu/polymode#87) in poly markdown modes. It's hard to reproduce. I have tracked it down to markdown proper and it's due to the fact that cached matched data at POS ends at (1- POS). This is strange. I don't have a reproducible example outside polymode but I am pretty sure it must be happening in simple markdown files as well. You might have a better idea of why and where this dismatch in position happens. 

This pull is a generic fix of such anomalies directly in `markdown-match-propertized-text`. It simply ensures that matcher moves the point at least one char beyond current point. This is what internal font lock code expects and implements itself (`font-lock-fontify-keywords-region`). Info for function matcher suggests the same:

>     Fontification will call FUNCTION repeatedly with the same limit,
>     and with point where the previous invocation left it, until
>     FUNCTION fails.  On failure, FUNCTION need not reset point in any
>     particular way.

I am attaching the relevant part of the tracing that clearly pins it on infloop of `markdown-match-heading-1-atx` which returns matched data (1331 1345) while the current point and the position where this data was cached is 1346. 


```
| | 3 -> (font-lock-fontify-region 1332 1334) [buf:ANOVA.rapport pos:1333 type:nil (1456530692.318306)]
| | | 4 -> (font-lock-set-defaults) [buf:ANOVA.rapport pos:1333 type:nil (1456530692.318326)]
| | | 4 <- font-lock-set-defaults: nil [buf:ANOVA.rapport pos:1333 type:nil (1456530692.318345)]
| | | 4 -> (poly-lock-fontify-region 1332 1334 nil) [buf:ANOVA.rapport pos:1333 type:nil (1456530692.318362)]
| | | | 5 -> (pm-map-over-spans (lambda nil (let ((inhibit-point-motion-hooks t)) (let* ((modified (buffer-modified-p)) (buffer-undo-list . #1=(t)) (inhibit-read-only . #1#) (inhibit-modification-hooks . #1#)) (unwind-protect (progn (let ((sbeg (nth 1 *span*)) (send (nth 2 *span*))) (if (and font-lock-mode font-lock-keywords (> send sbeg)) (progn (if parse-sexp-lookup-properties (progn (pm--comment-region 1 sbeg))) (let ((new-beg (max sbeg beg)) (new-end (min send end))) (condition-case err (if (eieio-oref pm/chunkmode (quote :font-lock-narrow)) (save-restriction (narrow-to-region sbeg send) (font-lock-unfontify-region new-beg new-end) (funcall pm--fontify-region-original new-beg new-end verbose)) (funcall pm--fontify-region-original new-beg new-end verbose)) ((debug error) (message "(poly-lock-fontify-region %s %s) -> (%s %s %s %s): %s " beg end pm--fontify-region-original new-beg new-end verbose (error-message-string err)))) (put-text-property new-beg new-end (quote fontified) t)) (if parse-sexp-lookup-properties (progn (pm--uncomment-region 1 sbeg))))) (pm--adjust-chunk-face sbeg send (pm-get-adjust-face pm/chunkmode)))) (if modified nil (restore-buffer-modified-p nil)))))) 1332 1334) [buf:ANOVA.rapport pos:1333 type:nil (1456530692.318384)]
| | | | | 6 -> (pm-get-innermost-span 1332 nil) [buf:ANOVA.rapport pos:1332 type:nil (1456530692.318472)]
| | | | | 6 <- pm-get-innermost-span: (nil 1329 1555 [eieio-class-tag--pm-bchunkmode [eieio-class-tag--pm-bchunkmode unbound "Markdown-1" markdown-mode t 0 t nil nil] "Markdown" markdown-mode t 0 t nil #<buffer ANOVA.rapport>]) [buf:ANOVA.rapport pos:1332 type:nil (1456530692.318499)]
| | | | | 6 -> (pm-get-innermost-span 1332 nil) [buf:ANOVA.rapport pos:1332 type:nil (1456530692.318525)]
| | | | | 6 <- pm-get-innermost-span: (nil 1329 1555 [eieio-class-tag--pm-bchunkmode [eieio-class-tag--pm-bchunkmode unbound "Markdown-1" markdown-mode t 0 t nil nil] "Markdown" markdown-mode t 0 t nil #<buffer ANOVA.rapport>]) [buf:ANOVA.rapport pos:1332 type:nil (1456530692.318549)]
| | | | | 6 -> (font-lock-unfontify-region 1332 1334) [buf:ANOVA.rapport pos:1329 type:nil (1456530692.318599)]
| | | | | | 7 -> (font-lock-default-unfontify-region 1332 1334) [buf:ANOVA.rapport pos:1329 type:nil (1456530692.318621)]
| | | | | | 7 <- font-lock-default-unfontify-region: t [buf:ANOVA.rapport pos:1329 type:nil (1456530692.318644)]
| | | | | 6 <- font-lock-unfontify-region: t [buf:ANOVA.rapport pos:1329 type:nil (1456530692.318661)]
| | | | | 6 -> (font-lock-default-fontify-region 1332 1334 nil) [buf:ANOVA.rapport pos:1329 type:nil (1456530692.318678)]
| | | | | | 7 -> (font-lock-extend-region-wholelines) [buf:ANOVA.rapport pos:1329 type:nil (1456530692.318701)]
| | | | | | 7 <- font-lock-extend-region-wholelines: t [buf:ANOVA.rapport pos:1334 type:nil (1456530692.318722)]
| | | | | | 7 -> (font-lock-extend-region-multiline) [buf:ANOVA.rapport pos:1334 type:nil (1456530692.318739)]
| | | | | | 7 <- font-lock-extend-region-multiline: nil [buf:ANOVA.rapport pos:1334 type:nil (1456530692.318760)]
| | | | | | 7 -> (font-lock-unfontify-region 1331 1348) [buf:ANOVA.rapport pos:1334 type:nil (1456530692.318777)]
| | | | | | | 8 -> (font-lock-default-unfontify-region 1331 1348) [buf:ANOVA.rapport pos:1334 type:nil (1456530692.318808)]
| | | | | | | 8 <- font-lock-default-unfontify-region: t [buf:ANOVA.rapport pos:1334 type:nil (1456530692.318856)]
| | | | | | 7 <- font-lock-unfontify-region: t [buf:ANOVA.rapport pos:1334 type:nil (1456530692.318875)]
| | | | | | 7 -> (font-lock-fontify-syntactically-region 1331 1348 nil) [buf:ANOVA.rapport pos:1334 type:nil (1456530692.318891)]
| | | | | | 7 <- font-lock-fontify-syntactically-region: nil [buf:ANOVA.rapport pos:1348 type:nil (1456530692.318939)]
| | | | | | 7 -> (font-lock-fontify-keywords-region 1331 1348 nil) [buf:ANOVA.rapport pos:1348 type:nil (1456530692.318958)]
| | | | | | | 8 -> (markdown-match-yaml-metadata-begin 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.318982)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-yaml-metadata-begin 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319003)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319028)]
| | | | | | | 8 <- markdown-match-yaml-metadata-begin: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319045)]
| | | | | | | 8 -> (markdown-match-yaml-metadata-end 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319062)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-yaml-metadata-end 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319082)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319104)]
| | | | | | | 8 <- markdown-match-yaml-metadata-end: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319120)]
| | | | | | | 8 -> (markdown-match-yaml-metadata-key 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319138)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-metadata-key 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319157)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319178)]
| | | | | | | 8 <- markdown-match-yaml-metadata-key: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319196)]
| | | | | | | 8 -> (markdown-match-gfm-open-code-blocks 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319213)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-gfm-block-begin 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319234)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319255)]
| | | | | | | 8 <- markdown-match-gfm-open-code-blocks: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319272)]
| | | | | | | 8 -> (markdown-match-gfm-close-code-blocks 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319288)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-gfm-block-end 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319307)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319329)]
| | | | | | | 8 <- markdown-match-gfm-close-code-blocks: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319345)]
| | | | | | | 8 -> (markdown-match-gfm-code-blocks 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319362)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-gfm-code 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319382)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319403)]
| | | | | | | 8 <- markdown-match-gfm-code-blocks: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319419)]
| | | | | | | 8 -> (markdown-match-fenced-start-code-block 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319437)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-tilde-fence-begin 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319457)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319479)]
| | | | | | | 8 <- markdown-match-fenced-start-code-block: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319496)]
| | | | | | | 8 -> (markdown-match-fenced-end-code-block 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319512)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-tilde-fence-end 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319538)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319560)]
| | | | | | | 8 <- markdown-match-fenced-end-code-block: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319577)]
| | | | | | | 8 -> (markdown-match-fenced-code-blocks 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319595)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-fenced-code 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319615)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319637)]
| | | | | | | 8 <- markdown-match-fenced-code-blocks: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319654)]
| | | | | | | 8 -> (markdown-match-pre-blocks 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319671)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-pre 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319690)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319712)]
| | | | | | | 8 <- markdown-match-pre-blocks: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319728)]
| | | | | | | 8 -> (markdown-match-blockquotes 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319745)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-blockquote 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319766)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319798)]
| | | | | | | 8 <- markdown-match-blockquotes: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319815)]
| | | | | | | 8 -> (markdown-match-heading-1-setext 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319834)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-setext 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319854)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319885)]
| | | | | | | 8 <- markdown-match-heading-1-setext: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319914)]
| | | | | | | 8 -> (markdown-match-heading-2-setext 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319932)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-2-setext 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319964)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.319985)]
| | | | | | | 8 <- markdown-match-heading-2-setext: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320002)]
| | | | | | | 8 -> (markdown-match-heading-6-atx 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320019)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-6-atx 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320040)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320062)]
| | | | | | | 8 <- markdown-match-heading-6-atx: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320079)]
| | | | | | | 8 -> (markdown-match-heading-5-atx 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320096)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-5-atx 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320116)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320137)]
| | | | | | | 8 <- markdown-match-heading-5-atx: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320154)]
| | | | | | | 8 -> (markdown-match-heading-4-atx 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320171)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-4-atx 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320191)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320214)]
| | | | | | | 8 <- markdown-match-heading-4-atx: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320234)]
| | | | | | | 8 -> (markdown-match-heading-3-atx 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320251)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-3-atx 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320271)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320293)]
| | | | | | | 8 <- markdown-match-heading-3-atx: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320310)]
| | | | | | | 8 -> (markdown-match-heading-2-atx 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320327)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-2-atx 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320347)]
| | | | | | | | 9 <- markdown-match-propertized-text: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320369)]
| | | | | | | 8 <- markdown-match-heading-2-atx: nil [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320386)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320403)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1331 type:nil (1456530692.320423)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320446)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320470)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320501)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320522)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320544)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320567)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320593)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320613)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320635)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320657)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320682)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320702)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320724)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320746)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320771)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320802)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320833)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320859)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320884)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320904)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320925)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320948)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320973)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.320993)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321015)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321038)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321063)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321081)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321103)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321126)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321150)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321170)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321191)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321214)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321239)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321259)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321280)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321302)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321327)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321347)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321369)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321393)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321419)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321439)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321460)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321484)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321509)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321528)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321550)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321573)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321599)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321618)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321639)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321662)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321687)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321707)]
| | | | | | | | 9 <- markdown-match-propertized-text: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321728)]
| | | | | | | 8 <- markdown-match-heading-1-atx: (1331 1345 nil nil nil nil nil nil nil nil 1331 1332 1333 1345 1345 1345 #<buffer ANOVA.rapport>) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321751)]
| | | | | | | 8 -> (markdown-match-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321775)]
| | | | | | | | 9 -> (markdown-match-propertized-text markdown-heading-1-atx 1348) [buf:ANOVA.rapport pos:1346 type:nil (1456530692.321807)]
```