### PR TITLE
Correct beginning of inline code position

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2805,7 +2805,7 @@ Return nil otherwise."
 (defun markdown-match-inline-generic (regex last)
   "Match inline REGEX from the point to LAST."
   (when (re-search-forward regex last t)
-    (let ((bounds (markdown-code-block-at-pos (match-beginning 0))))
+    (let ((bounds (markdown-code-block-at-pos (match-beginning 1))))
       (if (null bounds)
           ;; Not in a code block: keep match data and return t when in bounds
           (<= (match-end 0) last)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2860,6 +2860,16 @@ only partially propertized."
             (point-min) (point-at-eol)
             'face (list markdown-bold-face)))))
 
+(ert-deftest test-markdown-parsing/inline-code ()
+  "Don't cause infinite loop for inline code just after code block
+Detail: https://github.com/jrblevin/markdown-mode/issues/115"
+  (markdown-test-string "---
+x: x
+---
+`x`
+"
+    (should (= (markdown-match-code (point-max)) (point-max)))))
+
 ;;; Reference Checking:
 
 (ert-deftest test-markdown-references/goto-line-button ()


### PR DESCRIPTION
markdown-regex-code starts with **"\\(?:\\`\\|[^\\]\\)\\(\\(`+\\)..."**. If cursor is beginning of buffer, `(match-beginning 0)` is on backtick. While cursor is not beginning of buffer, `(match-beginning 0)` is not on backtick and previous point of backtick.

```
---
foo:bar
---
`x`
```

In above example, `(match-beginning 0)` is point of after '---'. That point is a code block and '(markdown-code-block-at-pos pos)' returns non-nil, this causes infinite loop of markdown-match-inline-generic. `(match-beginning 1)` of markdown-regex-code always on backtick. We should use `(match-beginning 1)` instead of '(match-beginning 0') in such case.

This is related to #115.
CC: @dabrahams 