### PR TITLE
Remove autoload for .text

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -6634,8 +6634,6 @@ BEG and END are the limits of scanned region."
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.markdown\\'" . markdown-mode))
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.text\\'" . markdown-mode))
-;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode))
 
 


### PR DESCRIPTION
While .md and .markdown are clearly markdown files, the handling of .text is not a choice that markdown-mode should be making on the user's behalf without any opportunity to prevent it.