### PR TITLE
Prevent spurious bold fontification

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2831,11 +2831,19 @@ Return nil otherwise."
 (defun markdown-match-bold (last)
   "Match inline bold from the point to LAST."
   (when (markdown-match-inline-generic markdown-regex-bold last)
-    (set-match-data (list (match-beginning 2) (match-end 2)
+    (let ((begin (match-beginning 2)) (end (match-end 2)))
+      (cond
+       ((markdown-range-property-any
+         begin end 'face (list markdown-inline-code-face
+                               markdown-math-face))
+        (goto-char (1+ (match-end 0)))
+        (markdown-match-bold last))
+       (t
+        (set-match-data (list (match-beginning 2) (match-end 2)
                           (match-beginning 3) (match-end 3)
                           (match-beginning 4) (match-end 4)
                           (match-beginning 5) (match-end 5)))
-    (goto-char (1+ (match-end 0)))))
+        (goto-char (1+ (match-end 0))))))))
 
 (defun markdown-match-italic (last)
   "Match inline italics from the point to LAST."

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -1980,6 +1980,26 @@ the opening bracket of [^2], and then subsequent functions would kill [^2])."
    (markdown-test-range-has-face (point-min) (1- (point-max))
                                  markdown-pre-face)))
 
+(ert-deftest test-markdown-font-lock/no-bold-in-code ()
+  "Bold markers in inline code should not trigger bold."
+  (markdown-test-string
+   "`def __init__(self):`"
+   (markdown-test-range-has-face 8 11 markdown-inline-code-face))
+  (markdown-test-string
+   "`**foo` bar `baz**`"
+   (markdown-test-range-face-equals 2 6 markdown-inline-code-face)
+   (markdown-test-range-face-equals 9 11 nil)
+   (markdown-test-range-face-equals 14 18 markdown-inline-code-face)))
+
+(ert-deftest test-markdown-font-lock/no-bold-in-math ()
+  "Bold markers in math should not trigger bold."
+  (markdown-test-file "math.text"
+    (markdown-toggle-math t)
+    (funcall markdown-test-font-lock-function)
+    (markdown-test-range-has-face 279 299 markdown-math-face)
+    (markdown-test-range-has-face 301 308 nil)
+    (markdown-test-range-has-face 310 312 markdown-math-face)))
+
 (ert-deftest test-markdown-font-lock/code-1 ()
   "A simple inline code test."
   (markdown-test-file "inline.text"

--- a/tests/math.text
+++ b/tests/math.text
@@ -18,6 +18,8 @@ $x + 1$
 
 $e_{ik}$ in the statement the theorem about $V_k$
 
+$**η = (-1)^{k(n-k)}sη$, where $**η$, is the Hodge star applied twice.
+
 <!-- Local Variables: -->
 <!-- markdown-enable-math: t -->
 <!-- End: -->


### PR DESCRIPTION
In markdown-match-bold, add guard clauses similar to those in
markdown-match-italic, to make sure bold markers in code or math do not
result in bold fontification, eg in cases such as:

* `**foo` bar `baz**`
* `def __init__(self):`