### PR TITLE
Don't return point which is larger than point-max

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1520,7 +1520,7 @@ Function is called repeatedly until it returns nil. For details, see
              (code-match (markdown-code-block-at-pos end))
              (new-end (or (and code-match (cl-second code-match)) new-end)))
         (unless (and (eq new-start start) (eq new-end end))
-          (cons new-start new-end))))))
+          (cons new-start (min new-end (point-max))))))))
 
 (defun markdown-font-lock-extend-region-function (start end _)
   "Used in `jit-lock-after-change-extend-region-functions'.


### PR DESCRIPTION
Original code sometimes returns point larger than point-max, then
syntax-propertize function raises args-out-of-range signal.

This is related to
- http://qiita.com/PharaohKJ/items/a5b86404cfd60af68089(In Japanese)

CC: @PharaohKJ