### PR TITLE
Unmark buffer modified at markdown-unfontify-region-wiki-links

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -6274,8 +6274,12 @@ See `markdown-wiki-link-p' and `markdown-follow-wiki-link'."
 (defun markdown-unfontify-region-wiki-links (from to)
   "Remove wiki link faces from the region specified by FROM and TO."
   (interactive "*r")
-  (remove-text-properties from to '(font-lock-face markdown-link-face))
-  (remove-text-properties from to '(font-lock-face markdown-missing-link-face)))
+  (let ((modified (buffer-modified-p)))
+    (remove-text-properties from to '(font-lock-face markdown-link-face))
+    (remove-text-properties from to '(font-lock-face markdown-missing-link-face))
+    ;; remove-text-properties marks the buffer modified in emacs 24.3,
+    ;; undo that if it wasn't originally marked modified
+    (set-buffer-modified-p modified)))
 
 (defun markdown-fontify-region-wiki-links (from to)
   "Search region given by FROM and TO for wiki links and fontify them.


### PR DESCRIPTION
In Emacs 24.3 (tested Emacs 24.3.1 from Ubuntu 14.04 LTS) any Markdown buffer is marked as modified at creation when visiting the file (or activating the markdown major mode). This couldn't be reproduced in some later Emacs versions, like 24.4.1 from Debian Jessie.

The test / bisect script used to reproduce the bug is:

```sh
#!/bin/sh
rm -f \#README.md#
emacs -nw -Q -l markdown-mode.el \
    --eval '(setq enable-local-variables nil)' --visit README.md \
    --eval '(if (buffer-modified-p) (kill-emacs 1) (kill-emacs 0))'
```

The bisection showed that the commit that introduced this behavior was 3c2cfee, where the function `markdown-unfontify-region-wiki-links` is invoked from `markdown-mode` unless some non-default settings prevent it.

The problem seems to be that in Emacs 24.3 some `remove-text-properties` calls, like the ones in `markdown-unfontify-region-wiki-links`, mark the buffer modified. The proposed change unsets the buffer modified mark if it wasn't previously set.
