### PR TITLE
Don't correct header like statement in metadata

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4817,14 +4817,16 @@ See `imenu-create-index-function' and `imenu--index-alist' for details."
     (save-excursion
       (goto-char (point-min))
       (while (re-search-forward markdown-regex-header (point-max) t)
-        (cond
-         ((setq heading (match-string-no-properties 1))
-          (setq pos (match-beginning 1)))
-         ((setq heading (match-string-no-properties 5))
-          (setq pos (match-beginning 4))))
-        (or (> (length heading) 0)
-            (setq heading empty-heading))
-        (setq index (append index (list (cons heading pos)))))
+        (when (and (not (markdown-code-block-at-point))
+                   (not (markdown-text-property-at-point 'markdown-yaml-metadata-begin)))
+          (cond
+           ((setq heading (match-string-no-properties 1))
+            (setq pos (match-beginning 1)))
+           ((setq heading (match-string-no-properties 5))
+            (setq pos (match-beginning 4))))
+          (or (> (length heading) 0)
+              (setq heading empty-heading))
+          (setq index (append index (list (cons heading pos))))))
       index)))
 
 

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3990,6 +3990,25 @@ Detail: https://github.com/jrblevin/markdown-mode/issues/79"
                      (window-start) (window-point))
                     final-win-st-diff)))))))
 
+;; Tests for imenu
+
+(ert-deftest test-markdown-imenu/metadata ()
+  "Don't correct header like statement in metadata.
+https://github.com/jrblevin/markdown-mode/issues/145"
+  (markdown-test-string "---
+title = \"Blah\"
+comments = false
+---
+
+# Header1
+
+## Header2
+"
+    (let ((headers (mapcar #'car (markdown-imenu-create-flat-index))))
+      (should (member "Header1" headers))
+      (should (member "Header2" headers))
+      (should-not (member "comments = false" headers)))))
+
 (provide 'markdown-test)
 
 ;;; markdown-test.el ends here


### PR DESCRIPTION
##### before

![before](https://cloud.githubusercontent.com/assets/554281/17028016/136dd77e-4fa1-11e6-9efa-c8c0c6c237e8.png)

##### With this PR

![after](https://cloud.githubusercontent.com/assets/554281/17028013/10c2ce94-4fa1-11e6-85bd-24d6b38a5fa9.png)

This is related to #145
CC: @blaenk