### PR TITLE
Ignore header line at fill-paragraph

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -6744,6 +6744,7 @@ or \\[markdown-toggle-inline-images]."
                 ; options really only handle paragraph-starting prefixes,
                 ; not paragraph-ending suffixes:
                 ".*  $" ; line ending in two spaces
+                "^#+"
                 "[ \t]*\\[\\^\\S-*\\]:[ \t]*$") ; just the start of a footnote def
               "\\|"))
   (set (make-local-variable 'adaptive-fill-first-line-regexp)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3595,6 +3595,16 @@ Detail: https://github.com/jrblevin/markdown-mode/issues/79"
       (back-to-indentation)
       (should-not (looking-at-p "\\*foo")))))
 
+(ert-deftest test-markdown-filling/ignore-header ()
+  "# Test fill-paragraph for containing header line paragraph.
+https://github.com/jrblevin/markdown-mode/issues/159"
+  (markdown-test-string "# this is header line
+this is not header line
+"
+    (let ((fill-column 10))
+      (fill-paragraph)
+      (should (string= (buffer-substring (point) (line-end-position)) "# this is header line")))))
+
 ;;; Export tests:
 
 (ert-deftest test-markdown-hook/xhtml-standalone ()


### PR DESCRIPTION
This is related to #159.

#### Before

![before](https://cloud.githubusercontent.com/assets/554281/18028242/9b44350a-6cb4-11e6-96c4-85633c5d1681.gif)

#### After

![after](https://cloud.githubusercontent.com/assets/554281/18028243/a18825ca-6cb4-11e6-8079-567d2b35c3c2.gif)

