### PR TITLE
use non-greedy *? for display math content

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -6476,9 +6476,9 @@ This is an exact copy of `line-number-at-pos' for use in emacs21."
     ;; Update font lock keywords with extensions
     (setq markdown-mode-font-lock-keywords
           (append
+           (markdown-mode-font-lock-keywords-math)
            markdown-mode-font-lock-keywords-basic
-           (markdown-mode-font-lock-keywords-wiki-links)
-           (markdown-mode-font-lock-keywords-math)))
+           (markdown-mode-font-lock-keywords-wiki-links)))
     ;; Update font lock defaults
     (setq font-lock-defaults
           '(markdown-mode-font-lock-keywords

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1442,7 +1442,7 @@ Groups 1 and 3 match opening and closing dollar signs.
 Group 3 matches the mathematical expression contained within.")
 
 (defconst markdown-regex-math-display
-  "^\\(\\\\\\[\\)\\(\\(?:.\\|\n\\)*\\)?\\(\\\\\\]\\)$"
+  "^\\(\\\\\\[\\)\\(\\(?:.\\|\n\\)*?\\)?\\(\\\\\\]\\)$"
   "Regular expression for itex \[..\] display mode expressions.
 Groups 1 and 3 match the opening and closing delimiters.
 Group 2 matches the mathematical expression contained within.")

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3745,7 +3745,14 @@ this is not header line
    (markdown-test-range-has-face 212 215 markdown-markup-face)
    (markdown-test-range-has-face 218 218 markdown-markup-face)
    (markdown-test-range-has-face 219 223 markdown-math-face)
-   (markdown-test-range-has-face 224 224 markdown-markup-face)))
+   (markdown-test-range-has-face 224 224 markdown-markup-face)
+   (markdown-test-range-has-face 350 351 markdown-markup-face)
+   (markdown-test-range-has-face 352 354 markdown-math-face)
+   (markdown-test-range-has-face 355 356 markdown-markup-face)
+   (markdown-test-range-has-face 357 376 nil)
+   (markdown-test-range-has-face 377 378 markdown-markup-face)
+   (markdown-test-range-has-face 379 381 markdown-math-face)
+   (markdown-test-range-has-face 382 383 markdown-markup-face)))
 
 (ert-deftest test-markdown-math/font-lock-italics ()
   "Test markdown math mode with underscores."

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3747,12 +3747,12 @@ this is not header line
    (markdown-test-range-has-face 219 223 markdown-math-face)
    (markdown-test-range-has-face 224 224 markdown-markup-face)
    (markdown-test-range-has-face 350 351 markdown-markup-face)
-   (markdown-test-range-has-face 352 354 markdown-math-face)
-   (markdown-test-range-has-face 355 356 markdown-markup-face)
-   (markdown-test-range-has-face 357 376 nil)
-   (markdown-test-range-has-face 377 378 markdown-markup-face)
-   (markdown-test-range-has-face 379 381 markdown-math-face)
-   (markdown-test-range-has-face 382 383 markdown-markup-face)))
+   (markdown-test-range-has-face 352 356 markdown-math-face)
+   (markdown-test-range-has-face 357 358 markdown-markup-face)
+   (markdown-test-range-has-face 359 391 nil)
+   (markdown-test-range-has-face 392 393 markdown-markup-face)
+   (markdown-test-range-has-face 394 398 markdown-math-face)
+   (markdown-test-range-has-face 399 400 markdown-markup-face)))
 
 (ert-deftest test-markdown-math/font-lock-italics ()
   "Test markdown math mode with underscores."

--- a/tests/math.text
+++ b/tests/math.text
@@ -20,11 +20,9 @@ $e_{ik}$ in the statement the theorem about $V_k$
 
 $**η = (-1)^{k(n-k)}sη$, where $**η$, is the Hodge star applied twice.
 
-\[ a \]
-
-This is not math
-
-\[ b \]
+\[ a_1 \]
+This is neither math nor italic
+\[ a_2 \]
 
 <!-- Local Variables: -->
 <!-- markdown-enable-math: t -->

--- a/tests/math.text
+++ b/tests/math.text
@@ -20,6 +20,12 @@ $e_{ik}$ in the statement the theorem about $V_k$
 
 $**η = (-1)^{k(n-k)}sη$, where $**η$, is the Hodge star applied twice.
 
+\[ a \]
+
+This is not math
+
+\[ b \]
+
 <!-- Local Variables: -->
 <!-- markdown-enable-math: t -->
 <!-- End: -->


### PR DESCRIPTION
Using greedy `*` means that the regex will match across display math blocks. For example, the current regex matches this whole snippet (including the non-math bit in the middle):

```
\[
some math
\]
non-math
\[
more math
\]
```

The only potential downside I can see is that if, for some strange reason, someone wants a literal `\]` inside their display math block, the regex will think that the block ends early. But this seems less likely than the frustrating situation of having non-math font-locked as math in between two display math blocks (which is very common in my documents).