### PR TITLE
Fix markdown-header-face inherit from nil error

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2165,8 +2165,8 @@ Used when `markdown-header-scaling' is non-nil."
 (defun markdown-make-header-faces ()
   "Build the faces used for Markdown headers."
   (defface markdown-header-face
-    `((t (:inherit (,(when markdown-header-scaling 'variable-pitch)
-                     font-lock-function-name-face)
+    `((t (:inherit (,@(when markdown-header-scaling 'variable-pitch)
+                    font-lock-function-name-face)
                    :weight bold)))
     "Base face for headers."
     :group 'markdown-faces)


### PR DESCRIPTION
When `markdown-header-scaling` is `nil`, the `:inherit` attribute value of `markdown-header-face` will be `(nil font-lock-function-name-faces)`. When exporting html from org-mode file which contains markdown source block, it will lead to an "Invalid face" error.