### PR TITLE
add contents feature

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8700,8 +8700,7 @@ If BUFFER is nil, use the current buffer"
 	   (-map #'(lambda (elt)
 		     (let ((text (cdr (assoc 'text elt)))
 			   (level (cdr (assoc 'level elt))))
-                       (->> (make-list (* 2 (- level 2)) " ")
-                            (apply #'concat))
+                       (insert (apply #'concat (make-list (* 2 (- level 2)) " ")))
 		       (insert (format "* [%s](#%s)\n" text
                                        (markdown-title-to-link text)))))))
       (buffer-string))))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8696,13 +8696,13 @@ If BUFFER is nil, use the current buffer"
                                 (level . ,(length (match-string 1))))))))))
     (with-temp-buffer
       (insert "## Conents\n\n")
-      (->> (cdr heads)
-	   (-map #'(lambda (elt)
-		     (let ((text (cdr (assoc 'text elt)))
-			   (level (cdr (assoc 'level elt))))
-                       (insert (apply #'concat (make-list (* 2 (- level 2)) " ")))
-		       (insert (format "* [%s](#%s)\n" text
-                                       (markdown-title-to-link text)))))))
+      (mapc #'(lambda (elt)
+                (let ((text (cdr (assoc 'text elt)))
+                      (level (cdr (assoc 'level elt))))
+                  (insert (apply #'concat (make-list (* 2 (- level 2)) " ")))
+                  (insert (format "* [%s](#%s)\n" text
+                                  (markdown-title-to-link text)))))
+              (cdr heads))
       (buffer-string))))
 
 (defun markdown-contents-insert ()

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8692,27 +8692,26 @@ If BUFFER is nil, use the current buffer"
 	(while (re-search-forward "^\\(#+\\)[ \t]*\\(.*\\)$" nil t)
 	  (setq heads (->> `((text . ,(match-string 2))
 			     (level . ,(length (match-string 1))))
-			   list
+                           (list)
 			   (append heads))))))
     (with-temp-buffer
       (insert "## Conents\n\n")
-      (->> heads
-	   rest
+      (->> (cdr heads)
 	   (-map #'(lambda (elt)
-		     (let ((text (->> elt (assoc 'text) cdr))
-			   (level (->> elt (assoc 'level) cdr)))
-		       (dotimes (i (* 2 (- level 2)))
-			 (insert " "))
-		       (->> (markdown-title-to-link text)
-			    (format "* [%s](#%s)\n" text)
-			    insert)))))
+		     (let ((text (cdr (assoc 'text elt)))
+			   (level (cdr (assoc 'level elt))))
+                       (->> (make-list (* 2 (- level 2)) " ")
+                            (apply #'concat))
+		       (insert (format "* [%s](#%s)\n" text
+                                       (markdown-title-to-link text)))))))
       (buffer-string))))
 
 (defun markdown-contents-insert ()
   "Create the markdown contents at the current point.
 See `markdown-contents-create'."
   (interactive)
-  (insert (markdown-contents-create)))
+  (save-excursion
+    (insert (markdown-contents-create))))
 
 
 (provide 'markdown-mode)


### PR DESCRIPTION
This feature inserts a table of contents into the markdown file by looking for leading hashes `(#)` and using the header text.  Links are created for each header to each section found.