### PR TITLE
Fix markdown-inline-code-face's :inherit attribute

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2515,7 +2515,7 @@ See `markdown-hide-markup' for additional details."
   :group 'markdown-faces)
 
 (defface markdown-inline-code-face
-  '((t (:inherit markdown-code-face font-lock-constant-face)))
+  '((t (:inherit (markdown-code-face font-lock-constant-face))))
   "Face for inline code."
   :group 'markdown-faces)
 


### PR DESCRIPTION
Hi! When inline code lost its foreground color some months ago,
I assumed it was a stylistic choice and did not question it; when
I tried to Customize the face recently, however, the Custom menu
spewed a broken face form.

AFAIK :inherit takes either a single face, or a sequence of faces, so
I guess the declaration ought to be fixed?
