### PR TITLE
Adds hook markdown-remove-gfm-checkbox-overlays

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8594,6 +8594,13 @@ BEG and END are the limits of scanned region."
        (progn (goto-char beg) (beginning-of-line) (point))
        (progn (goto-char end) (forward-line 1) (point))))))
 
+(defun markdown-remove-gfm-checkbox-overlays ()
+  "Remove all GFM checkbox overlays in buffer."
+  (save-excursion
+    (save-restriction
+      (widen)
+      (remove-overlays nil nil 'face 'markdown-gfm-checkbox-face))))
+
 
 ;;; Display inline image =================================================
 
@@ -8972,7 +8979,8 @@ position."
   ;; Make checkboxes buttons
   (when markdown-make-gfm-checkboxes-buttons
     (markdown-make-gfm-checkboxes-buttons (point-min) (point-max))
-    (add-hook 'after-change-functions #'markdown-gfm-checkbox-after-change-function t t))
+    (add-hook 'after-change-functions #'markdown-gfm-checkbox-after-change-function t t)
+    (add-hook 'change-major-mode-hook #'markdown-remove-gfm-checkbox-overlays t t))
 
   ;; edit-indirect
   (add-hook 'edit-indirect-after-commit-functions


### PR DESCRIPTION
Hook added to `change-major-mode-hook` when `markdown-make-gfm-checkboxes` is non-nil.

Closes #238