### PR TITLE
Don’t test the value of the internal property ‘composition’

### DIFF
--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2877,7 +2877,7 @@ takes precedence)."
       (markdown-test-range-has-face 932 949 markdown-url-face)
       (markdown-test-range-has-face 951 957 markdown-link-title-face)
       (markdown-test-range-has-face 958 958 markdown-markup-face)
-      (should (equal '((26 . 8734)) (get-text-property 932 'composition))))))
+      (should (get-text-property 932 'composition)))))
 
 (ert-deftest test-markdown-font-lock/hidden-urls-reference ()
   "Test URL hiding and toggling."
@@ -2897,7 +2897,7 @@ takes precedence)."
       (markdown-test-range-has-face 6 7 markdown-markup-face)
       (markdown-test-range-has-face 8 27 markdown-reference-face)
       (markdown-test-range-has-face 28 28 markdown-markup-face)
-      (should (equal '((20 . 8734)) (get-text-property 8 'composition))))))
+      (should (get-text-property 8 'composition)))))
 
 (ert-deftest test-markdown-font-lock/snake-case-code-in-heading ()
   "Test underscores in inline code in headings."


### PR DESCRIPTION
Fixes #246