### PR TITLE
Don’t insert trailing whitespace when inserting a blockquote

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -975,6 +975,7 @@
 (require 'url-parse)
 (require 'button)
 (require 'color)
+(require 'rx)
 
 (defvar jit-lock-start)
 (defvar jit-lock-end)
@@ -4735,7 +4736,9 @@ region.  The characters PREFIX will appear at the beginning
 of each line."
   (save-excursion
     (let* ((end-marker (make-marker))
-           (beg-marker (make-marker)))
+           (beg-marker (make-marker))
+           (prefix-without-trailing-whitespace
+            (replace-regexp-in-string (rx (+ blank) eos) "" prefix)))
       ;; Ensure blank line after and remove extra whitespace
       (goto-char end)
       (skip-syntax-backward "-")
@@ -4752,7 +4755,8 @@ of each line."
       (goto-char beg-marker)
       (while (and (< (line-beginning-position) end-marker)
                   (not (eobp)))
-        (insert prefix)
+        ;; Don’t insert trailing whitespace.
+        (insert (if (eolp) prefix-without-trailing-whitespace prefix))
         (forward-line)))))
 
 (defun markdown-blockquote-region (beg end)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -922,6 +922,11 @@ Test point position upon removal and insertion."
                         (should (looking-at "^        > $"))
                         (should (markdown-next-line-blank-p))))
 
+(ert-deftest test-markdown-insertion/blockquote-region-with-newline ()
+  (markdown-test-string "a\n\nb\n"
+    (markdown-blockquote-region 1 (point-max))
+    (should (equal (buffer-string) "> a\n>\n> b\n\n"))))
+
 (ert-deftest test-markdown-insertion/empty-italic ()
   "Test `markdown-insert-italic' with no word at point and no region."
   (markdown-test-string ""


### PR DESCRIPTION
Fixes #227