### PR TITLE
Allow ‘markdown-command’ and ‘markdown-open-command’ to be functions

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -579,7 +579,10 @@
 ;;
 ;;   * `markdown-command' - the command used to run Markdown (default:
 ;;     `markdown`).  This variable may be customized to pass
-;;     command-line options to your Markdown processor of choice.
+;;     command-line options to your Markdown processor of choice.  It can
+;;     also be a function; in this case `markdown' will call it with three
+;;     arguments: the beginning and end of the region to process, and
+;;     a buffer to write the output to.
 ;;
 ;;   * `markdown-command-needs-filename' - set to `t' if
 ;;     `markdown-command' does not accept standard input (default:
@@ -588,7 +591,9 @@
 ;;     When set to `t', `markdown-mode' will pass the name of the file
 ;;     as the final command-line argument to `markdown-command'.  Note
 ;;     that in the latter case, you will only be able to run
-;;     `markdown-command' from buffers which are visiting a file.
+;;     `markdown-command' from buffers which are visiting a file.  If
+;;     `markdown-command' is a function, `markdown-command-needs-filename'
+;;     is ignored.
 ;;
 ;;   * `markdown-open-command' - the command used for calling a standalone
 ;;     Markdown previewer which is capable of opening Markdown source files
@@ -597,6 +602,8 @@
 ;;     A representative program is the Mac app [Marked 2][], a
 ;;     live-updating Markdown previewer which can be [called from a
 ;;     simple shell script](https://jblevins.org/log/marked-2-command).
+;;     This variable can also be a function; in this case `markdown-open'
+;;     will call it without arguments to preview the current buffer.
 ;;
 ;;   * `markdown-hr-strings' - list of strings to use when inserting
 ;;     horizontal rules.  Different strings will not be distinguished
@@ -1033,7 +1040,7 @@ Any changes to the output buffer made by this hook will be saved.")
 (defcustom markdown-command "markdown"
   "Command to run markdown."
   :group 'markdown
-  :type 'string)
+  :type '(choice (string :tag "Shell command") function))
 
 (defcustom markdown-command-needs-filename nil
   "Set to non-nil if `markdown-command' does not accept input from stdin.
@@ -1047,9 +1054,10 @@ buffers which are visiting a file."
   "Command used for opening Markdown files directly.
 For example, a standalone Markdown previewer.  This command will
 be called with a single argument: the filename of the current
-buffer."
+buffer.  It can also be a function, which will be called without
+arguments."
   :group 'markdown
-  :type '(choice file (const :tag "None" nil)))
+  :type '(choice file function (const :tag "None" nil)))
 
 (defcustom markdown-hr-strings
   '("-------------------------------------------------------------------------------"
@@ -7482,7 +7490,7 @@ Return the name of the output buffer used."
         (setq output-buffer-name markdown-output-buffer-name))
       (cond
        ;; Handle case when `markdown-command' does not read from stdin
-       (markdown-command-needs-filename
+       ((and (stringp markdown-command) markdown-command-needs-filename)
         (if (not buffer-file-name)
             (user-error "Must be visiting a file")
           (shell-command (concat markdown-command " "
@@ -7494,9 +7502,11 @@ Return the name of the output buffer used."
           (with-current-buffer buf
             (setq buffer-read-only nil)
             (erase-buffer))
-          (call-process-region begin-region end-region
-                               shell-file-name nil buf nil
-                               shell-command-switch markdown-command)))))
+          (if (stringp markdown-command)
+              (call-process-region begin-region end-region
+                                   shell-file-name nil buf nil
+                                   shell-command-switch markdown-command)
+            (funcall markdown-command begin-region end-region buf))))))
     output-buffer-name))
 
 (defun markdown-standalone (&optional output-buffer-name)
@@ -7811,12 +7821,14 @@ update this buffer's contents."
 (defun markdown-open ()
   "Open file for the current buffer with `markdown-open-command'."
   (interactive)
-  (if (not markdown-open-command)
-      (user-error "Variable `markdown-open-command' must be set")
-    (if (not buffer-file-name)
-        (user-error "Must be visiting a file")
-      (call-process markdown-open-command
-                    nil nil nil buffer-file-name))))
+  (unless markdown-open-command
+    (user-error "Variable `markdown-open-command' must be set"))
+  (if (stringp markdown-open-command)
+      (if (not buffer-file-name)
+          (user-error "Must be visiting a file")
+        (call-process markdown-open-command nil nil nil buffer-file-name))
+    (funcall markdown-open-command))
+  nil)
 
 (defun markdown-kill-ring-save ()
   "Run Markdown on file and store output in the kill ring."

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5255,6 +5255,25 @@ comments = false
       (should (member "Header2" headers))
       (should-not (member "comments = false" headers)))))
 
+(ert-deftest test-markdown-command/function ()
+  "Test ‘markdown’ with ‘markdown-command’ being a function."
+  (markdown-test-string "foo"
+    (let* ((calls ())
+           (markdown-command (lambda (&rest args) (push args calls)))
+           (buffer-name (markdown))
+           (buffer (get-buffer buffer-name)))
+      (should (stringp buffer-name))
+      (should (buffer-live-p buffer))
+      (should (equal calls `((1 4 ,buffer)))))))
+
+(ert-deftest test-markdown-open-command/function ()
+  "Test ‘markdown-open’ with ‘markdown-open-command’ being a function."
+  (markdown-test-string ""
+    (let* ((calls 0)
+           (markdown-open-command (lambda () (cl-incf calls))))
+      (markdown-open)
+      (should (equal calls 1)))))
+
 (provide 'markdown-test)
 
 ;;; markdown-test.el ends here


### PR DESCRIPTION
Fixes #255