### PR TITLE
markdown-code-face is defined twice

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2520,11 +2520,6 @@ See `markdown-hide-markup' for additional details."
   "Face for inline code, pre blocks, and fenced code blocks."
   :group 'markdown-faces)
 
-(defface markdown-code-face
-  `((t (:inherit fixed-pitch)))
-  "Face for inline code, pre blocks, and fenced code blocks."
-  :group 'markdown-faces)
-
 (defface markdown-inline-code-face
   '((t (:inherit (markdown-code-face font-lock-constant-face))))
   "Face for inline code."


### PR DESCRIPTION
Hello, you created a duplicate of `markdown-code-face` by commit 7bf073664938f16a3bb7c0172db5102fd9874880, so I think the old one can be removed, right?
