### PR TITLE
Better gfm table recognition

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9142,6 +9142,12 @@ This version removes characters with invisibility property
 
 ;; Functions for maintaining tables
 
+(defvar markdown-table-at-point-p-function nil
+  "Function to decide if point is inside a table.
+
+The indirection serves to differentiate between standard markdown
+tables and gfm tables which are less strict about the markup.")
+
 (defconst markdown-table-line-regexp "^[ \t]*|"
   "Regexp matching any line inside a table.")
 
@@ -9156,10 +9162,55 @@ This version removes characters with invisibility property
 
 (defun markdown-table-at-point-p ()
   "Return non-nil when point is inside a table."
+  (if (functionp markdown-table-at-point-p-function)
+      (funcall markdown-table-at-point-p-function)
+    (markdown--table-at-point-p)))
+
+(defun markdown--table-at-point-p ()
+  "Return non-nil when point is inside a table."
   (save-excursion
     (beginning-of-line)
     (and (looking-at-p markdown-table-line-regexp)
          (not (markdown-code-block-at-point-p)))))
+
+(defconst gfm-table-line-regexp "^.?*|"
+  "Regexp matching any line inside a table.")
+
+(defconst gfm-table-hline-regexp "^-+\\(|-\\)+"
+  "Regexp matching hline inside a table.")
+
+;; GFM simplified tables syntax is as follows:
+;; - A header line for the column names, this is any text
+;;   separated by `|'.
+;; - Followed by a string -|-|- ..., the number of dashes is optional
+;;   but must be higher than 1. The number of separators should match
+;;   the number of columns.
+;; - Followed by the rows of data, which has the same format as the
+;;   header line.
+;; Example:
+;;
+;; foo | bar
+;; ------|---------
+;; bar | baz
+;; bar | baz
+(defun gfm--table-at-point-p ()
+  "Return non-nil when point is inside a gfm-compatible table."
+  (or (markdown--table-at-point-p)
+      (save-excursion
+        (beginning-of-line)
+        (when (looking-at-p gfm-table-line-regexp)
+          ;; we might be at the first line of the table, check if the
+          ;; line below is the hline
+          (or (save-excursion
+                (forward-line 1)
+                (looking-at-p gfm-table-hline-regexp))
+              ;; go up to find the header
+              (catch 'done
+                (while (looking-at-p gfm-table-line-regexp)
+                  (when (looking-at-p gfm-table-hline-regexp)
+                    (throw 'done t))
+                  (forward-line -1))
+                nil))))))
 
 (defun markdown-table-hline-at-point-p ()
   "Return non-nil when point is on a hline in a table.
@@ -9922,6 +9973,7 @@ spaces, or alternatively a TAB should be used as the separator."
   (setq markdown-link-space-sub-char "-")
   (setq markdown-wiki-link-search-subdirectories t)
   (setq-local font-lock-defaults '(gfm-font-lock-keywords))
+  (setq-local markdown-table-at-point-p-function 'gfm--table-at-point-p)
   ;; do the initial link fontification
   (markdown-gfm-parse-buffer-for-languages))
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9157,9 +9157,6 @@ tables and gfm tables which are less strict about the markup.")
 (defconst markdown-table-dline-regexp "^[ \t]*|[^-:]"
   "Regexp matching dline inside a table.")
 
-(defconst markdown-table-border-regexp "^[ \t]*[^| \t]"
-  "Regexp matching any line outside a table.")
-
 (defun markdown-table-at-point-p ()
   "Return non-nil when point is inside a table."
   (if (functionp markdown-table-at-point-p-function)
@@ -9222,22 +9219,22 @@ This function assumes point is on a table."
 (defun markdown-table-begin ()
   "Find the beginning of the table and return its position.
 This function assumes point is on a table."
-  (cond
-   ((save-excursion
-      (and (re-search-backward markdown-table-border-regexp nil t)
-           (line-beginning-position 2))))
-   (t (point-min))))
+  (save-excursion
+    (while (and (not (bobp))
+                (markdown-table-at-point-p))
+      (forward-line -1))
+    (unless (bobp)
+      (forward-line 1))
+    (point)))
 
 (defun markdown-table-end ()
   "Find the end of the table and return its position.
 This function assumes point is on a table."
   (save-excursion
-    (cond
-     ((re-search-forward markdown-table-border-regexp nil t)
-      (match-beginning 0))
-     (t (goto-char (point-max))
-        (skip-chars-backward " \t")
-        (if (bolp) (point) (line-end-position))))))
+    (while (and (not (eobp))
+                (markdown-table-at-point-p))
+      (forward-line 1))
+    (point)))
 
 (defun markdown-table-get-dline ()
   "Return index of the table data line at point.

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7577,7 +7577,7 @@ This puts point at the start of the current subtree, and mark at the end."
   (interactive)
   (let ((beg))
     (if (markdown-heading-at-point)
-	(beginning-of-line)
+        (beginning-of-line)
       (markdown-previous-visible-heading 1))
     (setq beg (point))
     (markdown-end-of-subtree)
@@ -7592,9 +7592,9 @@ This puts point at the start of the current subtree, and mark at the end."
       (narrow-to-region
        (progn (markdown-back-to-heading-over-code-block t) (point))
        (progn (markdown-end-of-subtree)
-	      (if (and (markdown-heading-at-point) (not (eobp)))
-		  (backward-char 1))
-	      (point))))))
+          (if (and (markdown-heading-at-point) (not (eobp)))
+          (backward-char 1))
+          (point))))))
 
 
 ;;; Generic Structure Editing, Completion, and Cycling Commands ===============
@@ -9478,7 +9478,7 @@ Create new table lines if required."
   (if (or (looking-at "[ \t]*$")
           (save-excursion (skip-chars-backward " \t") (bolp)))
       (newline)
-	(markdown-table-align)
+    (markdown-table-align)
     (let ((col (markdown-table-get-column)))
       (beginning-of-line 2)
       (if (or (not (markdown-table-at-point-p))


### PR DESCRIPTION
Add code to detect gfm tables.

## Description

in gfm tables do not require the leading `|` so they can simply look like this


    foo | bar
    ----|-----
    one | two

foo | bar
-----|-----
one | two

    asdasda | asdasd
    -|-
    onkjkjkjkje | two
    one | two
    -|-
    one | two

asdasda | asdasd
-|-
onkjkjkjkje | two
one | two
-|-
one | two

There is also a change of the table begin/end routines to use `markdown-table-at-point-p` instead of a special regexp to detect bounds. This makes the recognition depend only on one predicate instead of a regular expression which might vary between markdown implementations.

It is potentially slower than a regexp-based solution, but the performance hit is quite invisible in real-world usage---even on 1000 line tables it is pretty much instant on my 1.2ghz celeron CPU.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation at the beginning of `markdown-mode.el` if needed.
- [ ] If documentation was added or changed, I have updated the **README.md** file using `webpage.sh`.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).
