### PR TITLE
Fontify tables

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2652,6 +2652,11 @@ inline code fragments and code blocks."
   "Face for preformatted text."
   :group 'markdown-faces)
 
+(defface markdown-table-face
+  '((t (:inherit (markdown-code-face))))
+  "Face for tables."
+  :group 'markdown-faces)
+
 (defface markdown-language-keyword-face
   '((t (:inherit font-lock-type-face)))
   "Face for programming language identifiers."
@@ -2843,6 +2848,7 @@ Depending on your font, some reasonable choices are:
                                             (5 markdown-markup-properties nil t)))
     (markdown-match-gfm-close-code-blocks . ((0 markdown-markup-properties)))
     (markdown-fontify-gfm-code-blocks)
+    (markdown-fontify-tables)
     (markdown-match-fenced-start-code-block . ((1 markdown-markup-properties)
                                                (2 markdown-markup-properties nil t)
                                                (3 markdown-language-keyword-properties nil t)
@@ -4188,6 +4194,15 @@ Group 7: closing filename delimiter"
         (when (match-end 6)
           (add-text-properties
            (match-beginning 6) (match-end 6) right-markup-props))))
+    t))
+
+(defun markdown-fontify-tables (last)
+  (when (and (re-search-forward "|" last t)
+             (markdown-table-at-point-p))
+    (font-lock-append-text-property
+     (line-beginning-position) (min (1+ (line-end-position)) (point-max))
+     'face 'markdown-table-face)
+    (forward-line 1)
     t))
 
 (defun markdown-fontify-blockquotes (last)


### PR DESCRIPTION
Add a face for table fontification.

## Description

It is convenient to use variable pitch fonts in markdown as it's mostly text, but some markup such as tables becomes quite unruly with that.  This patch adds fontification of tables and by default inherits from code face which makes tables use fixed-width font.

## Related Issue

Some discussion happened here: https://github.com/jrblevin/markdown-mode/issues/207

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation at the beginning of `markdown-mode.el` if needed.
- [ ] If documentation was added or changed, I have updated the **README.md** file using `webpage.sh`.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).
