### PR TITLE
Signal errors when executing ‘markdown-command’ or ‘markdown-open-command’ fails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,8 @@
     -   Make code block language detection handle unspecified
         or unknown code block languages.  ([GH-284][])
     -   Fix precedence of inline code over inline links.
+    -   Improve error reporting for `markdown` and `markdown-open`.
+        ([GH-291][])
 
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171
   [gh-216]: https://github.com/jrblevin/markdown-mode/issues/216
@@ -129,6 +131,7 @@
   [gh-276]: https://github.com/jrblevin/markdown-mode/issues/276
   [gh-277]: https://github.com/jrblevin/markdown-mode/pull/277
   [gh-284]: https://github.com/jrblevin/markdown-mode/issues/284
+  [gh-291]: https://github.com/jrblevin/markdown-mode/issues/291
   [gh-296]: https://github.com/jrblevin/markdown-mode/issues/296
 
 # Markdown Mode 2.3

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5733,6 +5733,24 @@ https://github.com/jrblevin/markdown-mode/issues/235"
       (should (buffer-live-p buffer))
       (should (equal calls `((1 4 ,buffer)))))))
 
+(ert-deftest test-markdown-command/does-not-exist ()
+  "Test ‘markdown’ with a non-existing ‘markdown-command’."
+  (skip-unless (not (file-executable-p "/does/not/exist")))
+  (markdown-test-string "foo"
+    (let* ((markdown-command "/does/not/exist")
+           (data (should-error (markdown) :type 'user-error)))
+      (should (string-prefix-p "/does/not/exist failed with exit code "
+                               (error-message-string data))))))
+
+(ert-deftest test-markdown-command/fails ()
+  "Test ‘markdown’ with a failing ‘markdown-command’."
+  (skip-unless (executable-find "false"))
+  (markdown-test-string "foo"
+    (let* ((markdown-command "false")
+           (data (should-error (markdown) :type 'user-error)))
+      (should (string-prefix-p "false failed with exit code "
+                               (error-message-string data))))))
+
 (ert-deftest test-markdown-open-command/function ()
   "Test ‘markdown-open’ with ‘markdown-open-command’ being a function."
   (markdown-test-string ""
@@ -5740,6 +5758,26 @@ https://github.com/jrblevin/markdown-mode/issues/235"
            (markdown-open-command (lambda () (cl-incf calls))))
       (markdown-open)
       (should (equal calls 1)))))
+
+(ert-deftest test-markdown-open-command/does-not-exist ()
+  "Test ‘markdown-open’ with a non-existing ‘markdown-open-command’."
+  (skip-unless (not (file-executable-p "/does/not/exist")))
+  (markdown-test-string "foo"
+    (let ((buffer-file-name
+           (expand-file-name "bar.md" temporary-file-directory))
+          (markdown-open-command "/does/not/exist"))
+      (should-error (markdown-open) :type 'file-error))))
+
+(ert-deftest test-markdown-open-command/fails ()
+  "Test ‘markdown-open’ with a failing ‘markdown-open-command’."
+  (skip-unless (executable-find "false"))
+  (markdown-test-string "foo"
+    (let* ((buffer-file-name
+            (expand-file-name "bar.md" temporary-file-directory))
+           (markdown-open-command "false")
+           (data (should-error (markdown-open) :type 'user-error)))
+      (should (string-prefix-p "false failed with exit code "
+                               (error-message-string data))))))
 
 (provide 'markdown-test)
 


### PR DESCRIPTION
Fixes #291

## Description

<!-- More detailed description of the changes if needed. -->

`markdown` and `markdown-open` now signal an error if the commands fail or the binaries don't exist.

## Related Issue

#291 

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
