### PR TITLE
Test for expected error when previewing a non-file-visiting buffer

### DIFF
--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5633,7 +5633,10 @@ x|"
     (markdown-mode)
 
     ;; Activating `markdown-live-preview-mode' signals error
-    (should-error (markdown-live-preview-mode))
+    (let ((data (should-error (markdown-live-preview-mode) :type 'user-error)))
+      (should (string-match-p
+               (rx bos "Buffer " (+ nonl) " does not visit a file" eos)
+               (error-message-string data))))
 
     ;; After trying to activate live preview mode, mode is not activated
     (should-not markdown-live-preview-mode)


### PR DESCRIPTION
This makes sure that the expected error isn’t masked by other kinds of
failures (e.g. failing ‘markdown-command’).

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
<!--

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
