### PR TITLE
Fix "failed with exit code nil" when `markdown-open-command`

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7520,7 +7520,7 @@ update this buffer's contents."
       (if (not buffer-file-name)
           (user-error "Must be visiting a file")
         (save-buffer)
-        (let ((exit-code (call-process markdown-open-command nil 0 nil
+        (let ((exit-code (call-process markdown-open-command nil nil nil
                                        buffer-file-name)))
           ;; The exit code can be a signal description string, so don’t use ‘=’
           ;; or ‘zerop’.

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5864,7 +5864,7 @@ https://github.com/jrblevin/markdown-mode/issues/235"
             (expand-file-name "bar.md" temporary-file-directory))
            (markdown-open-command "false")
            (data (should-error (markdown-open) :type 'user-error)))
-      (should (string-prefix-p "false failed with exit code "
+      (should (string-prefix-p "false failed with exit code 1"
                                (error-message-string data))))))
 
 (provide 'markdown-test)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
* If DESTINATION is 0, `call-process' returns immediately with value nil
* We have to set DESTINATION nil and wait for PROGRAM to terminate so we can get exit code

<!-- More detailed description of the changes if needed. -->

## Related Issue

#291 #301

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
