### PR TITLE
Bind markdown-insert-list-item to M-RET rather than M-<return>

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5383,7 +5383,7 @@ Assumes match data is available for `markdown-regex-italic'."
     (define-key map (kbd "C-c S-<right>") 'markdown-table-insert-column)
     (define-key map (kbd "C-c C-M-h") 'markdown-mark-subtree)
     (define-key map (kbd "C-x n s") 'markdown-narrow-to-subtree)
-    (define-key map (kbd "M-<return>") 'markdown-insert-list-item)
+    (define-key map (kbd "M-RET") 'markdown-insert-list-item)
     (define-key map (kbd "C-c C-j") 'markdown-insert-list-item)
     ;; Paragraphs (Markdown context aware)
     (define-key map [remap backward-paragraph] 'markdown-backward-paragraph)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -1079,6 +1079,16 @@ Don't adjust spacing if tabs are used as whitespace."
     (call-interactively 'markdown-insert-list-item)
     (should (string-equal (buffer-string)  "9.\tfoo\n10.\t"))))
 
+(ert-deftest test-markdown-insertion/list-item-bound-keys ()
+  "Test that `markdown-insert-list-item' is bound to M-RET and equivalents."
+  (markdown-test-string "- foo"
+                        (goto-char (point-max))
+                        (execute-kbd-macro (read-kbd-macro "M-RET bar C-M-m baz"))
+                        (should (string-equal (buffer-string) "- foo\n- bar\n- baz"))
+                        (when (display-graphic-p)
+                          (execute-kbd-macro (read-kbd-macro "M-<return> quux"))
+                          (should (string-equal (buffer-string) "- foo\n- bar\n- baz\n- quux")))))
+
 (ert-deftest test-markdown-insertion/nested-list-marker ()
   "Test marker detection for `markdown-insert-list-item'."
   (markdown-test-string


### PR DESCRIPTION
**tl;dr** This is consistent with org-mode and tex-mode and fixes the binding for terminals.

## Description

`<return>` refers to the actual function key, which cannot be picked up by Emacs in a terminal.  AFAIU this is because terminals translate function keys into character sequences *before* they tell the application what is going on.  So:

- `<return>` is translated into RET ≡ `\r` ≡ `^M`
- `M-<return>` is translated into M-RET ≡ `\E\r` ≡ `^[^M`

In graphical frames, Emacs knows that `<return>` was pressed, and translates it to RET if there is no binding specifically for `<return>`; in terminals, Emacs has no idea that `<return>` was pressed.

As a side effect, this change also makes C-M-m insert new list items since C-m ≡ RET ≡ "control character 13".

(The first commit message provides additional ~~gory details~~ explanations)

## Related Issue

I did not raise an issue.  Let me know if you feel this deserves more discussion; I will open one.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

⚠ NITPICKING ⚠ Not sure about some checkboxes:

- It's not really a bug fix because I did not open a formal issue; it does fix the binding in a terminal though.
- Does adding more bindings (`C-M-m`) count as a new feature?
- It could be a breaking change for people who bind `M-RET`.

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
    - I did not find explicit mentions of `<return>` in the documentation; I took a look at [the guide] and it actually mentions `M-RET`, so I guess everything works out?
- [ ] I have added an entry to **CHANGES.md**.
    - Not yet; would the following work under "Bug fixes"?
        > Fix M-RET binding for terminals ([GH-TODO][])
        >
        > [gh-TODO]: https://github.com/jrblevin/markdown-mode/pull/TODO
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).

Originally, the test checked for `M-<return>` unconditionally:

``` elisp
(ert-deftest test-markdown-insertion/list-item-bound-keys ()
  "Test that `markdown-insert-list-item' is bound to M-RET and equivalents."
  (markdown-test-string "- foo"
                        (goto-char (point-max))
                        (execute-kbd-macro (read-kbd-macro "M-RET bar C-M-m baz M-<return> quux"))
                        (should (string-equal (buffer-string) "- foo\n- bar\n- baz\n- quux"))))
```

This does not pass when run with `make test`, though it does pass when run in a graphical Emacs:

    emacs -Q
    M-x load-file RET markdown-mode.el RET
    M-x load-file RET tests/markdown-test.el RET
    M-x ert-run-tests-interactively RET test-markdown-insertion/list-item-bound-keys RET

I am assuming this is because `--batch` does not load a window system; hence I added `(when display-graphic-p …)` before testing `M-<return>`.

[the guide]: https://github.com/jrblevin/markdown-mode-guide/blob/master/manuscript/guide.txt
