### PR TITLE
skip empty URLs when inlining images

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8376,7 +8376,8 @@ or \\[markdown-toggle-inline-images]."
         (let ((start (match-beginning 0))
               (end (match-end 0))
               (file (match-string-no-properties 6)))
-          (when (file-exists-p file)
+          (when (and (not (zerop (length file)))
+		     (file-exists-p file))
             (let* ((abspath (if (file-name-absolute-p file)
                                 file
                               (concat default-directory file)))


### PR DESCRIPTION
## Description

Markdown links like `[foo]()`, while basically invalid, do not usually
cause too much trouble, or at least shouldn't cause problems in
unrelated code. It so happens that if a document happens to have such
a link, `markdown-toggle-inline-images` will crash with:

    insert-file-contents-literally: not a regular file: /tmp/default-directory-path/

This patch fixes the problem by checking if the `file` path extracted
from the regex is empty before proceeding with treating it like an image.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).
