### PR TITLE
Checking unused references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,8 @@
     -   Add custom variables `markdown-xhtml-body-preamble` and
         `markdown-xhtml-body-epilogue` for wrapping additional XHTML
         tags around the output.  ([GH-280][], [GH-281][])
+    -   Add `markdown-unused-refs` command to list and clean up unused
+        references (available via `C-c C-c u`)
 
 *   Improvements:
 

--- a/README.md
+++ b/README.md
@@ -355,6 +355,11 @@ can obtain a list of all keybindings by pressing <kbd>C-c C-h</kbd>.
     end of the buffer.  Similarly, selecting the line number will
     jump to the corresponding line.
 
+    <kbd>C-c C-c u</kbd> will check for unused references.  This will
+    also open a small buffer if any are found, similar to undefined
+    reference checking.  The buffer for unused references will contain
+    `X` buttons that remove unused references when selected.
+
     <kbd>C-c C-c n</kbd> renumbers any ordered lists in the buffer that are
     out of sequence.
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2788,7 +2788,7 @@ intact additional processing."
       (while (re-search-forward markdown-regex-reference-definition nil t)
         (let ((target (match-string-no-properties 2)))
           (cl-pushnew
-           (cons target
+           (cons (downcase target)
                  (markdown-line-number-at-pos (match-beginning 2)))
            refs :test #'equal :key #'car)))
       (reverse refs))))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5883,7 +5883,7 @@ The string %buffer% will be replaced by the corresponding buffer name.")
               (markdown-check-refs t))))
 
 ;; Jump to line in buffer specified by 'target-buffer property.
-;; Line number is button's 'line property.
+;; Line number is button's 'target-line property.
 (define-button-type 'markdown-goto-line-button
   'help-echo "mouse-1, RET: go to line"
   'follow-link t
@@ -5911,7 +5911,7 @@ The string %buffer% will be replaced by the corresponding buffer name.")
 (defun markdown-insert-undefined-reference-button (reference oldbuf)
   "Insert a button for creating REFERENCE in buffer OLDBUF.
 REFERENCE should be a list of the form (reference . occurrences),
-as by `markdown-get-undefined-refs'."
+as returned by `markdown-get-undefined-refs'."
   (let ((label (car reference)))
     ;; Create a reference button
     (insert-button label

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5889,7 +5889,6 @@ The string %buffer% will be replaced by the corresponding buffer name.")
   'follow-link t
   'face 'italic
   'action (lambda (b)
-            (message (button-get b 'buffer))
             (switch-to-buffer-other-window (button-get b 'target-buffer))
             ;; use call-interactively to silence compiler
             (let ((current-prefix-arg (button-get b 'target-line)))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5811,9 +5811,11 @@ For example, an alist corresponding to [Nice editor][Emacs] at line 12,
   (markdown-for-all-refs markdown-collect-undefined))
 
 (defun markdown-get-unused-refs ()
-  (cl-set-difference
-   (markdown-get-defined-references) (markdown-get-all-refs)
-   :test (lambda (e1 e2) (equal (car e1) e2))))
+  (cl-sort
+   (cl-set-difference
+    (markdown-get-defined-references) (markdown-get-all-refs)
+    :test (lambda (e1 e2) (equal (car e1) e2)))
+   #'< :key #'cdr))
 
 (defmacro defun-markdown-buffer (name docstring)
   "Define a function to name and return a buffer.

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -409,9 +409,9 @@ nil to disable this."
 The car is used for subscript, the cdr is used for superscripts."
   :group 'markdown
   :type '(cons (choice (sexp :tag "Subscript form")
-		       (const :tag "No lowering" nil))
-	       (choice (sexp :tag "Superscript form")
-		       (const :tag "No raising" nil)))
+                       (const :tag "No lowering" nil))
+               (choice (sexp :tag "Superscript form")
+                       (const :tag "No raising" nil)))
   :package-version '(markdown-mode . "2.4"))
 
 (defcustom markdown-unordered-list-item-prefix "  * "

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5815,25 +5815,26 @@ For example, an alist corresponding to [Nice editor][Emacs] at line 12,
    (markdown-get-defined-references) (markdown-get-all-refs)
    :test (lambda (e1 e2) (equal (car e1) e2))))
 
-(defconst markdown-unused-references-buffer
-  "*Unused references for %buffer%*"
-  "Pattern for name of buffer for listing unused references.
-The string %buffer% will be replaced by the corresponding
-`markdown-mode' buffer name.")
+(defmacro defun-markdown-buffer (name docstring)
+  "Define a function to name and return a buffer.
 
-(defun markdown-unused-references-buffer (&optional buffer-name)
-  "Name and return buffer for unused reference checking.
-BUFFER-NAME is the name of the main buffer being visited."
-  (or buffer-name (setq buffer-name (buffer-name)))
-  (let ((refbuf (get-buffer-create (markdown-replace-regexp-in-string
-                                    "%buffer%" buffer-name
-                                    markdown-unused-references-buffer))))
-    (with-current-buffer refbuf
-      (when view-mode
-        (View-exit-and-edit))
-      (use-local-map button-buffer-map)
-      (erase-buffer))
-    refbuf))
+By convention, NAME must be a name of a string constant with
+%buffer% placeholder used to name the buffer, and will also be
+used as a name of the function defined.
+
+DOCSTRING will be used as the first part of the docstring."
+  `(defun ,name (&optional buffer-name)
+     ,(concat docstring "\n\nBUFFER-NAME is the name of the main buffer being visited.")
+     (or buffer-name (setq buffer-name (buffer-name)))
+     (let ((refbuf (get-buffer-create (markdown-replace-regexp-in-string
+                                       "%buffer%" buffer-name
+                                       ,name))))
+       (with-current-buffer refbuf
+         (when view-mode
+           (View-exit-and-edit))
+         (use-local-map button-buffer-map)
+         (erase-buffer))
+       refbuf)))
 
 (defconst markdown-reference-check-buffer
   "*Undefined references for %buffer%*"
@@ -5841,38 +5842,28 @@ BUFFER-NAME is the name of the main buffer being visited."
 The string %buffer% will be replaced by the corresponding
 `markdown-mode' buffer name.")
 
-(defun markdown-reference-check-buffer (&optional buffer-name)
-  "Name and return buffer for reference checking.
-BUFFER-NAME is the name of the main buffer being visited."
-  (or buffer-name (setq buffer-name (buffer-name)))
-  (let ((refbuf (get-buffer-create (markdown-replace-regexp-in-string
-                                    "%buffer%" buffer-name
-                                    markdown-reference-check-buffer))))
-    (with-current-buffer refbuf
-      (when view-mode
-        (View-exit-and-edit))
-      (use-local-map button-buffer-map)
-      (erase-buffer))
-    refbuf))
+(defun-markdown-buffer
+  markdown-reference-check-buffer
+  "Name and return buffer for reference checking.")
+
+(defconst markdown-unused-references-buffer
+  "*Unused references for %buffer%*"
+  "Pattern for name of buffer for listing unused references.
+The string %buffer% will be replaced by the corresponding
+`markdown-mode' buffer name.")
+
+(defun-markdown-buffer
+  markdown-unused-references-buffer
+  "Name and return buffer for unused reference checking.")
 
 (defconst markdown-reference-links-buffer
   "*Reference links for %buffer%*"
   "Pattern for name of buffer for listing references.
 The string %buffer% will be replaced by the corresponding buffer name.")
 
-(defun markdown-reference-links-buffer (&optional buffer-name)
-  "Name, setup, and return a buffer for listing links.
-BUFFER-NAME is the name of the main buffer being visited."
-  (or buffer-name (setq buffer-name (buffer-name)))
-  (let ((linkbuf (get-buffer-create (markdown-replace-regexp-in-string
-                                     "%buffer%" buffer-name
-                                     markdown-reference-links-buffer))))
-    (with-current-buffer linkbuf
-      (when view-mode
-        (View-exit-and-edit))
-      (use-local-map button-buffer-map)
-      (erase-buffer))
-    linkbuf))
+(defun-markdown-buffer
+  markdown-reference-links-buffer
+  "Name, setup, and return a buffer for listing links.")
 
 ;; Add an empty Markdown reference definition to buffer
 ;; specified in the 'target-buffer property.  The reference name is

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2781,13 +2781,16 @@ intact additional processing."
                          (match-beginning 5) (match-end 5)))))))))
 
 (defun markdown-get-defined-references ()
-  "Return a list of all defined reference labels (not including square brackets)."
+  "Return all defined reference labels and their line numbers (not including square brackets)."
   (save-excursion
     (goto-char (point-min))
     (let (refs)
       (while (re-search-forward markdown-regex-reference-definition nil t)
         (let ((target (match-string-no-properties 2)))
-          (cl-pushnew target refs :test #'equal)))
+          (cl-pushnew
+           (cons target
+                 (markdown-line-number-at-pos (match-beginning 2)))
+           refs :test #'equal :key #'car)))
       (reverse refs))))
 
 (defun markdown-get-used-uris ()
@@ -3938,7 +3941,7 @@ This is an internal function called by
     (let* ((ref (when ref (concat "[" ref "]")))
            (defined-refs (append
                           (mapcar (lambda (ref) (concat "[" ref "]"))
-                                  (markdown-get-defined-references))))
+                                  (mapcar #'car (markdown-get-defined-references)))))
            (used-uris (markdown-get-used-uris))
            (uri-or-ref (completing-read
                         "URL or [reference]: "

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5938,6 +5938,7 @@ REFERENCE must be a pair of (ref . line-number)."
     ;; Create a reference button
     (insert-button label
                    :type 'markdown-goto-line-button
+                   'face 'bold
                    'target-buffer oldbuf
                    'target-line (cdr reference))
     (insert (format " (%d)\n" (cdr reference)))))

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3605,7 +3605,15 @@ only partially propertized."
   "Test `markdown-get-defined-references'."
   (markdown-test-file "syntax.text"
    (should (equal (markdown-get-defined-references)
-                  '("src" "1" "2" "3" "4" "5" "6" "bq" "l"))))
+                  '(("src" . 37)
+                    ("1" . 55)
+                    ("2" . 56)
+                    ("3" . 57)
+                    ("4" . 58)
+                    ("5" . 59)
+                    ("6" . 60)
+                    ("bq" . 205)
+                    ("l" . 206)))))
   (markdown-test-file "outline.text"
    (should (equal (markdown-get-defined-references) nil)))
   (markdown-test-file "wiki-links.text"

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3840,6 +3840,12 @@ puts 'hello, world'
                   '(("logorrhea" . 8)
                     ("orphan" . 11))))))
 
+(ert-deftest test-markdown-references/get-undefined-refs ()
+  "Test `markdown-get-undefined-refs'."
+  (markdown-test-file "refs.text"
+   (should (equal (markdown-get-undefined-refs)
+                  '(("problems" ("problems" . 3) ("controversy" . 5)))))))
+
 (ert-deftest test-markdown-references/goto-line-button ()
   "Create and test a goto line button."
   (markdown-test-string "line 1\nline 2\n"

--- a/tests/refs.text
+++ b/tests/refs.text
@@ -1,0 +1,11 @@
+Now this a pretty [long][graphomania] text. Written to conclude a
+period of intensive thinking, it spans many paragraphs, expressing the
+author's original views on numerous [problems][] of our society. Once
+published, it will draw international attention and spark
+[controversy][problems] for months to follow.
+
+[graphomania]: https://en.wikipedia.org/wiki/Graphomania
+[logorrhea]: https://en.wikipedia.org/wiki/Logorrhea_(psychology)
+
+
+[orphan]: http://some.link


### PR DESCRIPTION
## Description

This adds `markdown-unused-refs` command bound to <kbd>C-c C-c u</kbd> that will find orphaned references which are defined in the document footer but not actually linked to anywhere in the text. This works similarly to `markdown-check-refs`. The only difference is that pop-up buffer contains `[X]` buttons to remove unused references:

<img width="541" alt="screen shot 2018-03-25 at 02 13 40" src="https://user-images.githubusercontent.com/102053/37870608-2bd6c830-2fd2-11e8-8af8-5f9986f416e4.png">

This is useful when maintaining documents with dozens of links. Sometimes I remove a paragraph but the orphaned reference stays in the footer. `markdown-unused-refs` helps weed those out.

While testing I also noticed that `markdown-get-defined-references` may return duplicates for references defined more than once in different case, as in `[REF]:` and `[ref]:`. This also looks confusing in `markdown-insert-link` completion and caused issues implementing `markdown-unused-refs`, so `markdown-get-defined-references` results are now downcased. This is consistent with what `markdown-check-refs` returns and as per https://daringfireball.net/projects/markdown/syntax#link and
http://spec.commonmark.org/0.28/#matches link labels are
case-insensitive anyways. I don't think it should cause any issues in properly written Markdown files.

Some minor refactoring too  – moved duplicated code to macros.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves an existing feature)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have read the **CONTRIBUTING.md** document.
- [X] I have updated the documentation in the **README.md** file if necessary.
- [X] I have added an entry to **CHANGES.md**.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed (using `make test`).
