### PR TITLE
Add to beginning of auto-mode-alist, not end

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,12 @@
         `markdown-font-lock-keywords` is now used instead, but users
         should use `font-lock-add-keywords` instead of modifying this
         variable.
+    -   `markdown-mode` now adds entries to the beginning of
+        `auto-mode-alist` rather than the end. If you were relying on
+        the previous behavior in order to override these entries, you
+        should fix the problem by following best practice and ensuring
+        that your user configuration is loaded after the autoloads for
+        `markdown-mode` are evaluated.
 
 *   New features:
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9454,9 +9454,9 @@ spaces, or alternatively a TAB should be used as the separator."
   (add-hook 'kill-buffer-hook #'markdown-live-preview-remove-on-kill t t))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.markdown\\'" . markdown-mode) t)
+(add-to-list 'auto-mode-alist '("\\.markdown\\'" . markdown-mode))
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode) t)
+(add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode))
 
 
 ;;; GitHub Flavored Markdown Mode  ============================================


### PR DESCRIPTION
In Emacs 26, a file called `CHANGELOG.md` will open in `changelog-mode` instead of `markdown-mode`, because a regexp was added to `auto-mode-alist` that matches the `CHANGELOG` part of the filename. In order for the file to correctly open in `markdown-mode`, the regexps for `markdown-mode` must be added earlier in `auto-mode-alist`, hence this pull request.

There should be no concern about this overriding user configuration, since it makes no sense for user configuration code to be run before the autoloads for `markdown-mode` are evaluated.

This solves #331 and addresses my comment at https://github.com/jrblevin/markdown-mode/issues/127#issuecomment-379429784.

This is a **breaking change**, but only barely—if someone were relying on the previous behavior, I would consider it extraordinarily bad practice.

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).

Let me know if you think a test is required for this change.
