### PR TITLE
Customization group 'wp is depreciated -> 'text

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -88,7 +88,7 @@ Any changes to the output buffer made by this hook will be saved.")
 (defgroup markdown nil
   "Major mode for editing text files in Markdown format."
   :prefix "markdown-"
-  :group 'wp
+  :group 'text
   :link '(url-link "https://jblevins.org/projects/markdown-mode/"))
 
 (defcustom markdown-command "markdown"


### PR DESCRIPTION
Customization group 'wp is depreciated in 26.1 with advice to use 'text instead.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).
