### PR TITLE
Change default character encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,19 +749,19 @@ provides an interface to all of the possible customizations:
   * `markdown-css-paths` - CSS files to link to in XHTML output
     (default: `nil`).
 
-  * `markdown-content-type` - when set to a nonempty string, an
-    `http-equiv` attribute will be included in the XHTML `<head>`
-    block (default: `""`).  If needed, the suggested values are
-    `application/xhtml+xml` or `text/html`.  See also:
-    `markdown-coding-system`.
+  * `markdown-content-type` - used to set to the `http-equiv`
+    attribute to be included in the XHTML `<head>` block (default:
+    `"text/html"`).  Set to an alternate value `application/xhtml+xml`
+    if needed, or set to an empty string to remove the attribute.  See
+    also: `markdown-coding-system`.
 
   * `markdown-coding-system` - used for specifying the character
     set identifier in the `http-equiv` attribute when included
     (default: `nil`).  See `markdown-content-type`, which must
-    be set before this variable has any effect.  When set to `nil`,
+    be set for this variable to have any effect.  When set to `nil`,
     `buffer-file-coding-system` will be used to automatically
     determine the coding system string (falling back to
-    `iso-8859-1` when unavailable).  Common settings are `utf-8`
+    `utf-8` when unavailable).  Common settings are `iso-8859-1`
     and `iso-latin-1`.
 
   * `markdown-xhtml-header-content` - additional content to include

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -324,17 +324,17 @@ Math support can be enabled, disabled, or toggled later using
   :group 'markdown
   :type '(repeat (string :tag "CSS File Path")))
 
-(defcustom markdown-content-type ""
+(defcustom markdown-content-type "text/html"
   "Content type string for the http-equiv header in XHTML output.
-When set to a non-empty string, insert the http-equiv attribute.
-Otherwise, this attribute is omitted."
+When set to an empty string, this attribute is omitted.  Defaults to
+`text/html'."
   :group 'markdown
   :type 'string)
 
 (defcustom markdown-coding-system nil
   "Character set string for the http-equiv header in XHTML output.
 Defaults to `buffer-file-coding-system' (and falling back to
-`iso-8859-1' when not available).  Common settings are `utf-8'
+`utf-8' when not available).  Common settings are `iso-8859-1'
 and `iso-latin-1'.  Use `list-coding-systems' for more choices."
   :group 'markdown
   :type 'coding-system)
@@ -7313,7 +7313,7 @@ Standalone XHTML output is identified by an occurrence of
           "<head>\n<title>")
   (insert title)
   (insert "</title>\n")
-  (when (> (length markdown-content-type) 0)
+  (unless (= (length markdown-content-type) 0)
     (insert
      (format
       "<meta http-equiv=\"Content-Type\" content=\"%s;charset=%s\"/>\n"
@@ -7325,7 +7325,7 @@ Standalone XHTML output is identified by an occurrence of
           (and (fboundp 'coding-system-get)
                (coding-system-get buffer-file-coding-system
                                   'mime-charset))
-          "iso-8859-1"))))
+          "utf-8"))))
   (if (> (length markdown-css-paths) 0)
       (insert (mapconcat #'markdown-stylesheet-link-string
                          markdown-css-paths "\n")))


### PR DESCRIPTION
I changed the default character encoding in the generated preview document to UTF-8.

No breaking changes were introduced, but I'm happy to adjust this in case we're okay with dropping `markdown-content-type` altogether and switching to the [`charset`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta) attribute instead.

## Related Issue

I came across this when text doesn't render properly in the preview. It was German text in my case, but I'm sure it affects others too. This should also fix #340.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
