### PR TITLE
Don't consider point at the end of code-block as part of the code-block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@
         should fix the problem by following best practice and ensuring
         that your user configuration is loaded after the autoloads for
         `markdown-mode` are evaluated. ([GH-331][], [GH-335][])
+    -   Point at the end of fenced code blocks is no-longer considered
+        part of the code block ([GH-#349][]).
 
 *   New features:
 
@@ -86,6 +88,8 @@
 
 *   Bug fixes:
 
+    -   Fix infloop caused by incorrect detection of end of code
+        blocks ([GH-349][]).
     -   Remove GFM checkbox overlays when switching major modes.
         ([GH-238][], [GH-257][])
     -   Don't test the value of the `composition` property to avoid
@@ -115,7 +119,7 @@
     -   Do not fail displaying inline images on empty links. ([GH-320][])
     -   Fix off-by-one error in `markdown-inline-code-at-pos`.
         ([GH-313][])
-
+  [gh-349]: https://github.com/jrblevin/markdown-mode/issues/349]
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171
   [gh-216]: https://github.com/jrblevin/markdown-mode/issues/216
   [gh-222]: https://github.com/jrblevin/markdown-mode/issues/222

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3499,13 +3499,14 @@ echo hey
    (should (equal (markdown-code-block-at-pos 1) '(1 35)))
    (should (equal (markdown-code-block-at-pos 13) '(1 35)))
    (should (equal (markdown-code-block-at-pos 23) '(1 35)))
-   (should (equal (markdown-code-block-at-pos 35) '(1 35)))))
+   (should (equal (markdown-code-block-at-pos 34) '(1 35)))
+   (should (equal (markdown-code-block-at-pos 35) nil))))
 
 (ert-deftest test-markdown-parsing/code-block-at-pos-yaml-metadata ()
   "Ensure `markdown-code-block-at-pos' works in YAML metadata blocks."
   (let ((markdown-use-pandoc-style-yaml-metadata t))
     (markdown-test-string
-     "---
+      "---
 a: b
 ---
 
@@ -3520,7 +3521,7 @@ data: pandoc
      (should (equal (markdown-code-block-at-pos 15) '(15 35)))
      (should (equal (markdown-code-block-at-pos 19) '(15 35)))
      (should (equal (markdown-code-block-at-pos 34) '(15 35)))
-     (should (equal (markdown-code-block-at-pos 35) '(15 35))))))
+     (should (equal (markdown-code-block-at-pos 35) nil)))))
 
 (ert-deftest test-markdown-parsing/syntax-get-fenced-blocks ()
   "Test whether *-get-fenced-block-* functions work in the case where a block is


### PR DESCRIPTION
## Description

A few reasons for the change.

Given that emacs is forward-oriented regarding text properties at point
(`get-text-property` retrieves text property from the forward char and
`set-text-property` is end-exclusive) this change makes quite a lot of sense.

From the user prospective, cursor is often identified with the point and given
that block-cursor is blinking on the next character it's confusing for the user
to treat that pistons as part of the preceding block.

At least one other tool (polymode) adopts similar conversion.

## Related Issue

 #349

## Type of Change

I guess users won't see a difference.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).