### PR TITLE
Don't retrieve properties beyond `limit` in `markdown-match-propertized-text`

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3071,7 +3071,8 @@ Restore match data previously stored in PROPERTY."
         pos)
     (unless saved
       (setq pos (next-single-property-change (point) property nil last))
-      (setq saved (get-text-property pos property)))
+      (unless (= pos last)
+        (setq saved (get-text-property pos property))))
     (when saved
       (set-match-data saved)
       ;; Step at least one character beyond point. Otherwise


### PR DESCRIPTION
`next-single-property-change` in `markdown-match-propertized-text` returns the
`LIMIT` when no property has been found. This creates font-lock issues in
narrowed buffers (particularly in polymode chunks).

This is how it works, if narrowing is in place on a code span and a text
property lies just outside of the narrowed region then the current
implementation of `markdown-match-propertized-text` will search till
`(point-max)` and will retrieve the text property from outside of the relevant
region, causing out of range or end-of-buffer errors during font-lock.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).