### PR TITLE
Remove polymode fix and fix boundary check in markdown-code-block-at-pos

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2870,12 +2870,7 @@ quoted code blocks.  Return nil otherwise."
         (let ((bounds (markdown-get-enclosing-fenced-block-construct pos)))
           (and bounds
                (< pos (cl-second bounds))
-               bounds))
-        ;; polymode removes text properties set by markdown-mode, so
-        ;; check if `poly-markdown-mode' is active and whether the
-        ;; `chunkmode' property is non-nil at POS.
-        (and (bound-and-true-p poly-markdown-mode)
-             (get-text-property pos 'chunkmode)))))
+               bounds)))))
 
 ;; Function was renamed to emphasize that it does not modify match-data.
 (defalias 'markdown-code-block-at-point 'markdown-code-block-at-point-p)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2867,10 +2867,13 @@ This includes pre blocks, tilde-fenced code blocks, and GFM
 quoted code blocks.  Return nil otherwise."
   (let ((bol (save-excursion (goto-char pos) (point-at-bol))))
     (or (get-text-property bol 'markdown-pre)
-        (let ((bounds (markdown-get-enclosing-fenced-block-construct pos)))
-          (and bounds
-               (< pos (cl-second bounds))
-               bounds)))))
+        (let* ((bounds (markdown-get-enclosing-fenced-block-construct pos))
+               (second (cl-second bounds)))
+          (if second
+              ;; chunks are right open
+              (when (< pos second)
+                bounds)
+            bounds)))))
 
 ;; Function was renamed to emphasize that it does not modify match-data.
 (defalias 'markdown-code-block-at-point 'markdown-code-block-at-point-p)
@@ -2885,7 +2888,7 @@ data.  See `markdown-inline-code-at-point-p' for inline code."
 (defun markdown-heading-at-point (&optional pos)
   "Return non-nil if there is a heading at the POS.
 Set match data for `markdown-regex-header'."
-  (let ((match-data (get-text-property (or (point) pos) 'markdown-heading)))
+  (let ((match-data (get-text-property (or pos (point)) 'markdown-heading)))
     (when match-data
       (set-match-data match-data)
       t)))


### PR DESCRIPTION
Polymode was rewritten and it no longer interferes with markdown mode in any way. 

Regarding the boundary. In #355 I wrongly assumed that boundary can be either of the form `(123 456)` or nil. It turned out that that's not the case, it can be `(123 nil)` or even `(nil nil)`. Thus the current code in master throws invalid argument type on that comparison.

I am fixing this with a minimal check and passing the boundary downstream when second term is nil (like it used to be before), but I wonder if that's how this code should work. AFAICS the consumers of `markdown-get-enclosing-fenced-block-construct` and `markdown-code-block-at-pos` do seem to expect proper boundaries of the form `(123 456)`. So it's a bit surprising, in my mind, that things worked before :)