### PR TITLE
accept relative CSS stylesheets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,7 @@
     -   Support horizontal rules consisting of underscores.
     -   Change default character encoding to UTF-8.
         ([GH-340][], [GH-350][])
+    -   Allow relative CSS stylesheets paths.
 
 *   Bug fixes:
 

--- a/README.md
+++ b/README.md
@@ -754,7 +754,8 @@ provides an interface to all of the possible customizations:
     (default: `t`).
 
   * `markdown-css-paths` - CSS files to link to in XHTML output
-    (default: `nil`).
+    (default: `nil`). These can be either local files (relative or
+    absolute) or URLs.
 
   * `markdown-content-type` - used to set to the `http-equiv`
     attribute to be included in the XHTML `<head>` block (default:

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -320,7 +320,7 @@ Math support can be enabled, disabled, or toggled later using
   :package-version '(markdown-mode . "2.4"))
 
 (defcustom markdown-css-paths nil
-  "URL of CSS file to link to in the output XHTML."
+  "List of URLs of CSS files to link to in the output XHTML."
   :group 'markdown
   :type '(repeat (string :tag "CSS File Path")))
 
@@ -7320,7 +7320,9 @@ Standalone XHTML output is identified by an occurrence of
 
 (defun markdown-stylesheet-link-string (stylesheet-path)
   (concat "<link rel=\"stylesheet\" type=\"text/css\" media=\"all\" href=\""
-          stylesheet-path
+          (or (and (string-prefix-p "~" stylesheet-path)
+                   (expand-file-name stylesheet-path))
+              stylesheet-path)
           "\"  />"))
 
 (defun markdown-add-xhtml-header-and-footer (title)


### PR DESCRIPTION
## Description

This enables `markdown-mode` to understand a relative CSS stylesheet path. Since I just need a couple of CSS tweaks that I'll drag onto my different machines, this is welcome:

```lisp
(use-package markdown-mode
  :config
  (setq markdown-css-paths '("~/.emacs.d/markdown/style.css")))
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [X] I have read the **CONTRIBUTING.md** document.
- [X] I have updated the documentation in the **README.md** file if necessary.
- [X] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed (using `make test`).
