### PR TITLE
Fix the evaluation of markdown-split-window-direction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -126,6 +126,8 @@
     -   Fix off-by-one error in `markdown-inline-code-at-pos`.
         ([GH-313][])
     -   Fix bounds during inline comment syntax propertization. ([GH-327][])
+    -   Fix inverted meaning of 'vertical and 'horizontal for
+        markdown-split-window-direction
 
   [gh-349]: https://github.com/jrblevin/markdown-mode/issues/349]
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7549,9 +7549,9 @@ displaying the rendered output."
 (defun markdown-get-other-window ()
   "Find another window to display preview or output content."
   (cond
-   ((memq markdown-split-window-direction '(vertical below))
+   ((memq markdown-split-window-direction '(vertical right))
     (or (window-in-direction 'below) (split-window-vertically)))
-   ((memq markdown-split-window-direction '(horizontal right))
+   ((memq markdown-split-window-direction '(horizontal below))
     (or (window-in-direction 'right) (split-window-horizontally)))
    (t (split-window-sensibly (get-buffer-window)))))
 


### PR DESCRIPTION
## Description

According to the defcustom for markdown-split-window-direction, 'vertical
and 'right are equivalent, and 'horizontal and 'below are equivalent, but
the point of use had the meaning of 'vertical and 'horizontal reversed.

## Related Issue

I could not find an existing issue

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
