### PR TITLE
Declare variable aliases before their referent

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2122,6 +2122,14 @@ Depending on your font, some reasonable choices are:
          ,@(when markdown-hide-markup
              `(display ,markdown-footnote-display))))
 
+(define-obsolete-variable-alias
+ 'gfm-font-lock-keywords
+ 'markdown-mode-font-lock-keywords "v2.4")
+
+(define-obsolete-variable-alias
+ 'markdown-mode-font-lock-keywords-basic
+ 'markdown-mode-font-lock-keywords "v2.4")
+
 (defvar markdown-mode-font-lock-keywords
   `((markdown-match-yaml-metadata-begin . ((1 'markdown-markup-face)))
     (markdown-match-yaml-metadata-end . ((1 'markdown-markup-face)))
@@ -2226,10 +2234,6 @@ Depending on your font, some reasonable choices are:
     (markdown-fontify-blockquotes)
     (markdown-match-wiki-link . ((0 'markdown-link-face prepend))))
   "Syntax highlighting for Markdown files.")
-
-(define-obsolete-variable-alias
- 'markdown-mode-font-lock-keywords-basic
- 'markdown-mode-font-lock-keywords "v2.4")
 
 ;; Footnotes
 (defvar markdown-footnote-counter 0
@@ -9626,10 +9630,6 @@ rows and columns and the column alignment."
   (setq markdown-wiki-link-search-subdirectories t)
   (setq-local markdown-table-at-point-p-function 'gfm--table-at-point-p)
   (markdown-gfm-parse-buffer-for-languages))
-
-(define-obsolete-variable-alias
- 'gfm-font-lock-keywords
- 'markdown-mode-font-lock-keywords "v2.4")
 
 
 ;;; Viewing modes =============================================================


### PR DESCRIPTION
## Description

Since Emacs 27 the byte-compiler tells us to do that.
The warning is shown by `byte-compile-file-form-defvar-function',
which contains a comment providing this justification:

> Variable aliases are better declared before the corresponding variable,
> since it makes it more likely that only one of the two vars has a value
> before the `defvaralias' gets executed, which avoids the need to
> merge values.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).

I do not think adding a test would make sense.