### PR TITLE
Makes markdown-back-to-heading interactive with raw prefix argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,7 @@
 
 *   Improvements:
 
+    -   Make `markdown-back-to-heading` interactive for keybinding.
     -   Insert references before local variables.  Thanks to Philipp
         Stephani for a patch.  ([GH-216][], [GH-262][])
     -   Allow `markdown-command` and `markdown-open-command` to be

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -6759,6 +6759,7 @@ With argument, move up ARG levels."
 (defun markdown-back-to-heading (&optional invisible-ok)
   "Move to previous heading line, or beg of this line if it's a heading.
 Only visible heading lines are considered, unless INVISIBLE-OK is non-nil."
+  (interactive "P")
   (markdown-move-heading-common #'outline-back-to-heading invisible-ok))
 
 (defalias 'markdown-end-of-heading 'outline-end-of-heading)


### PR DESCRIPTION
Closes #415.

The function `markdown-back-to-heading` becomes interactive and can be assigned to a keypress. I manually tested calling it from a keypress without and with a prefix argument `C-u`.

## Related Issue

https://github.com/jrblevin/markdown-mode/issues/415

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).
