### PR TITLE
Autoload for mdwn files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,8 @@
     -   Support horizontal rules consisting of underscores.
     -   Change default character encoding to UTF-8.
         ([GH-340][], [GH-350][])
+    -   Also load markdown-mode for *.mdwn files.
+    -   Optimise the autoloaded add-to-alist 'auto-mode-alist section.
 
 *   Bug fixes:
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Then, after restarting Emacs or evaluating the above statements, issue
 the following command: <kbd>M-x package-install RET markdown-mode RET</kbd>.
 When installed this way, the major modes `markdown-mode` and `gfm-mode`
 will be autoloaded and `markdown-mode` will be used for file names
-ending in either `.md` or `.markdown`.
+ending in `.md`, `.markdown`, or `.mdwn`.
 
 Alternatively, if you manage loading packages with [use-package][]
 then you can automatically install and configure `markdown-mode` by
@@ -101,6 +101,7 @@ to load automatically by adding the following to your init file:
    "Major mode for editing Markdown files" t)
 (add-to-list 'auto-mode-alist '("\\.markdown\\'" . markdown-mode))
 (add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode))
+(add-to-list 'auto-mode-alist '("\\.mdwn\\'" . markdown-mode))
 
 (autoload 'gfm-mode "markdown-mode"
    "Major mode for editing GitHub Flavored Markdown files" t)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9613,11 +9613,11 @@ rows and columns and the column alignment."
   (add-hook 'kill-buffer-hook #'markdown-live-preview-remove-on-kill t t))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.markdown\\'" . markdown-mode))
-;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode))
-;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.mdwn\\'" . markdown-mode))
+(setq auto-mode-alist
+      (append auto-mode-alist
+              '(("\\.markdown\\'" . markdown-mode)
+                ("\\.md\\'" . markdown-mode)
+                ("\\.mdwn\\'" . markdown-mode))))
 
 
 ;;; GitHub Flavored Markdown Mode  ============================================

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9616,6 +9616,8 @@ rows and columns and the column alignment."
 (add-to-list 'auto-mode-alist '("\\.markdown\\'" . markdown-mode))
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.mdwn\\'" . markdown-mode))
 
 
 ;;; GitHub Flavored Markdown Mode  ============================================


### PR DESCRIPTION
## Description

This PR Adds support for autoloading markdown-mode when a foo.mdwn file is visited.  It also includes a minor optimisation and cleanup.  Please let me know if you'd like me to rebase and drop any of these commits.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).