### PR TITLE
Use window-body-width -1 for hr

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3546,7 +3546,7 @@ SEQ may be an atom or a sequence."
               font-lock-multiline t
               ,@(when (and markdown-hide-markup hr-char)
                   `(display ,(make-string
-                              (window-body-width) hr-char)))))
+                              (1- (window-body-width)) hr-char)))))
       t)))
 
 (defun markdown-fontify-sub-superscripts (last)


### PR DESCRIPTION
## Description

In console Emacs, a line of chars of length N will overhang a window-body-width of N by 1 because of the trailing slash. Using N-1 avoids this problem and seems to be the easiest way to not have hrs overhang each line.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
