### PR TITLE
Avoid matching code fragments as code blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -109,6 +109,9 @@
 
 *   Bug fixes:
 
+    -   No longer treat code fragments that are delimited with three
+        backquotes on each side as the beginning of a code block.
+        ([GH-403][])
     -   Fix infloop caused by incorrect detection of end of code
         blocks ([GH-349][]).
     -   Remove GFM checkbox overlays when switching major modes.

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -720,7 +720,7 @@ Groups 1 and 3 match the opening and closing tags.
 Group 2 matches the key sequence.")
 
 (defconst markdown-regex-gfm-code-block-open
-  "^[[:blank:]]*\\(?1:```\\)\\(?2:[[:blank:]]*{?[[:blank:]]*\\)\\(?3:[^[:space:]]+?\\)?\\(?:[[:blank:]]+\\(?4:.+?\\)\\)?\\(?5:[[:blank:]]*}?[[:blank:]]*\\)$"
+  "^[[:blank:]]*\\(?1:```\\)\\(?2:[[:blank:]]*{?[[:blank:]]*\\)\\(?3:[^`[:space:]]+?\\)?\\(?:[[:blank:]]+\\(?4:.+?\\)\\)?\\(?5:[[:blank:]]*}?[[:blank:]]*\\)$"
   "Regular expression matching opening of GFM code blocks.
 Group 1 matches the opening three backquotes and any following whitespace.
 Group 2 matches the opening brace (optional) and surrounding whitespace.


### PR DESCRIPTION
## Description

Code fragments should be delimited by one backquote on each side, but
some people use two or even three on each side.  Previously if three
were used then we wrongly identified that as the beginning of a code
block.  This resulted in the complete line being treated as syntax,
and hiding syntax therefore caused the complete line to be hidden.
Fix that by making sure no excess backquotes follow on the same line.

## Related Issue

Fixes #403.

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary. (not necessary)
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).

You are asking for quite a lot.  I could invest time figuring out how to write a test, but since I don't even know whether you see these pull-requests I skip doing that for now.  It would probably be much easier for you to write the tests, so I would very much appreciate it you could do that yourself. Considering that this is a one character change, I have already written an excessive amount of additional characters to justify why that character would be nice to have. ;-)