### PR TITLE
Don't treat as metadata if it is not in header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -126,6 +126,7 @@
     -   Fix off-by-one error in `markdown-inline-code-at-pos`.
         ([GH-313][])
     -   Fix bounds during inline comment syntax propertization. ([GH-327][])
+    -   Fix wrong metadata highlighting. ([GH-437][])
 
   [gh-349]: https://github.com/jrblevin/markdown-mode/issues/349]
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171
@@ -178,6 +179,7 @@
   [gh-350]: https://github.com/jrblevin/markdown-mode/pull/350
   [gh-369]: https://github.com/jrblevin/markdown-mode/pull/369
   [gh-378]: https://github.com/jrblevin/markdown-mode/pull/378
+  [gh-437]: https://github.com/jrblevin/markdown-mode/issues/437
 
 # Markdown Mode 2.3
 

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2810,6 +2810,14 @@ it is parsed."
    (markdown-test-range-has-face 42 67 nil)
    (markdown-test-range-has-face 69 88 nil)))
 
+(ert-deftest test-markdown-font-lock/mmd-not-metadata ()
+  "Don't treat as metadata if its line is not in header
+https://github.com/jrblevin/markdown-mode/issues/437"
+  (markdown-test-string "hello world
+foo bar baz: one two three
+"
+   (markdown-test-range-has-face 13 39 nil)))
+
 (ert-deftest test-markdown-font-lock/pandoc-metadata ()
   "Basic Pandoc metadata tests."
   (markdown-test-string "% title


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Fix wrong metadata highlighting issue. The line contains `:`, then original code highlights it as metadata if its line is not in metadata header.

### original code
![before](https://user-images.githubusercontent.com/554281/78989308-3b50ee00-7b6e-11ea-9d9b-8750be776571.png)

### with this patch
![after](https://user-images.githubusercontent.com/554281/78989321-41df6580-7b6e-11ea-80f2-48b020411b8b.png)


## Related Issue

https://github.com/jrblevin/markdown-mode/issues/437

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
