### PR TITLE
Fix wrong italic highlight in HTML attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,6 +127,7 @@
         ([GH-313][])
     -   Fix bounds during inline comment syntax propertization. ([GH-327][])
     -   Fix wrong metadata highlighting. ([GH-437][])
+    -   Fix wrong italic highlighting in HTML attributes. ([GH-410][])
 
   [gh-349]: https://github.com/jrblevin/markdown-mode/issues/349]
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171
@@ -179,6 +180,7 @@
   [gh-350]: https://github.com/jrblevin/markdown-mode/pull/350
   [gh-369]: https://github.com/jrblevin/markdown-mode/pull/369
   [gh-378]: https://github.com/jrblevin/markdown-mode/pull/378
+  [gh-410]: https://github.com/jrblevin/markdown-mode/issues/410
   [gh-437]: https://github.com/jrblevin/markdown-mode/issues/437
 
 # Markdown Mode 2.3

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1026,6 +1026,14 @@ Group 3 matches all attributes and whitespace following the tag name.")
 If POS is not given, use point instead."
   (get-text-property (or pos (point)) 'markdown-comment))
 
+(defun markdown-in-html-attr-p (pos)
+  "Return non-nil if POS is in a html attribute name or value."
+  (let ((face-prop (get-text-property pos 'face)))
+    (if (listp face-prop)
+        (cl-loop for face in face-prop
+                 thereis (memq face '(markdown-html-attr-name-face markdown-html-attr-value-face)))
+      (memq face-prop '(markdown-html-attr-name-face markdown-html-attr-value-face)))))
+
 (defun markdown-syntax-propertize-extend-region (start end)
   "Extend START to END region to include an entire block of text.
 This helps improve syntax analysis for block constructs.
@@ -2999,7 +3007,8 @@ When FACELESS is non-nil, do not return matches where faces have been applied."
   "Match inline italics from the point to LAST."
   (let ((regex (if (memq major-mode '(gfm-mode gfm-view-mode))
                    markdown-regex-gfm-italic markdown-regex-italic)))
-    (when (markdown-match-inline-generic regex last)
+    (when (and (markdown-match-inline-generic regex last)
+               (not (markdown-in-html-attr-p (match-beginning 1))))
       (let ((begin (match-beginning 1))
             (end (match-end 1)))
         (if (or (markdown-inline-code-at-pos-p begin)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2236,6 +2236,12 @@ See GH-275."
    (markdown-test-range-has-face 1 30 'markdown-comment-face)
    (should-not (markdown-range-property-any 1 30 'face '(markdown-italic-face)))))
 
+(ert-deftest test-markdown-font-lock/italics-in-html-attribute ()
+  "Test not matching italics in HTML attributes."
+  (markdown-test-string
+   "<meta a=\"b_c\" d=\"e_f\">"
+   (should-not (markdown-range-property-any 12 18 'face '(markdown-italic-face)))))
+
 (ert-deftest test-markdown-font-lock/italics-after-bold ()
   "Test bold and italics on the same line.
 See GH-223."


### PR DESCRIPTION
## Description
Don't treat `_` as italic meta character in HTML attributes

### Original
4th line style is italic

![before](https://user-images.githubusercontent.com/554281/79061342-50429400-7cca-11ea-93e8-d2f36b00dd8e.png)

### With this patch

![after](https://user-images.githubusercontent.com/554281/79061345-58023880-7cca-11ea-80f0-b07d4d3bfc70.png)


## Related Issue

https://github.com/jrblevin/markdown-mode/issues/410

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
