### PR TITLE
Fix markdown-link-p issue for continuous links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -128,6 +128,7 @@
     -   Fix bounds during inline comment syntax propertization. ([GH-327][])
     -   Fix wrong metadata highlighting. ([GH-437][])
     -   Fix wrong italic highlighting in HTML attributes. ([GH-410][])
+    -   Fix markdown-follow-thing-at-point issue for continuous links. ([GH-305][])
 
   [gh-349]: https://github.com/jrblevin/markdown-mode/issues/349]
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171
@@ -169,6 +170,7 @@
   [gh-291]: https://github.com/jrblevin/markdown-mode/issues/291
   [gh-296]: https://github.com/jrblevin/markdown-mode/issues/296
   [gh-303]: https://github.com/jrblevin/markdown-mode/pull/303
+  [gh-305]: https://github.com/jrblevin/markdown-mode/issues/305
   [gh-313]: https://github.com/jrblevin/markdown-mode/issues/313
   [gh-317]: https://github.com/jrblevin/markdown-mode/pull/317
   [gh-320]: https://github.com/jrblevin/markdown-mode/pull/320

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -4818,6 +4818,17 @@ like statement. Detail: https://github.com/jrblevin/markdown-mode/issues/75"
       (should (equal translated-files '("/foo/bar/baz")))
       (should (equal visited-files '("/root/foo/bar/baz.md"))))))
 
+(ert-deftest test-markdown-link/link-p ()
+  "Test that `markdown-link-p' returns t if cursor is on link."
+  (markdown-test-string "[one][two] [three][four]"
+    (should (markdown-link-p))
+    (goto-char 2)
+    (should (markdown-link-p))
+    (goto-char 12)
+    (should (markdown-link-p))
+    (goto-char 13)
+    (should (markdown-link-p))))
+
 ;;; Wiki link tests:
 
 (ert-deftest test-markdown-wiki-link/file-local-variables ()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

```markdown
[foo][bar] [one][two]
```

When cursor is on `foo`, `markdown-link-p` return nil, because `(thing-at-point-looking-at markdown-regex-link-reference)` returns nil, it matches against `[bar] [one]` and decides here is not link. So if cursor in link text then backward cursor to link start position(`[`) for avoiding this issue.j


## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

https://github.com/jrblevin/markdown-mode/issues/305

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
