### PR TITLE
Support more markdown extensions same as Vim

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,7 @@
     -   Support horizontal rules consisting of underscores.
     -   Change default character encoding to UTF-8.
         ([GH-340][], [GH-350][])
+    -   Support more markdown extensions same as Vim
 
 *   Bug fixes:
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Then, after restarting Emacs or evaluating the above statements, issue
 the following command: <kbd>M-x package-install RET markdown-mode RET</kbd>.
 When installed this way, the major modes `markdown-mode` and `gfm-mode`
 will be autoloaded and `markdown-mode` will be used for file names
-ending in either `.md` or `.markdown`.
+ending in `.md`, `.markdown`, `.mkd`, `.mdown`, `.mkdn`, `.mdwn`.
 
 Alternatively, if you manage loading packages with [use-package][]
 then you can automatically install and configure `markdown-mode` by
@@ -99,8 +99,8 @@ to load automatically by adding the following to your init file:
 ```lisp
 (autoload 'markdown-mode "markdown-mode"
    "Major mode for editing Markdown files" t)
-(add-to-list 'auto-mode-alist '("\\.markdown\\'" . markdown-mode))
-(add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode))
+(add-to-list 'auto-mode-alist
+             '("\\.\\(?:md\\|markdown\\|mkd\\|mdown\\|mkdn\\|mdwn\\)\\'" . markdown-mode))
 
 (autoload 'gfm-mode "markdown-mode"
    "Major mode for editing GitHub Flavored Markdown files" t)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9644,9 +9644,8 @@ rows and columns and the column alignment."
   (add-hook 'kill-buffer-hook #'markdown-live-preview-remove-on-kill t t))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.markdown\\'" . markdown-mode))
-;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode))
+(add-to-list 'auto-mode-alist
+             '("\\.\\(?:md\\|markdown\\|mkd\\|mdown\\|mkdn\\|mdwn\\)\\'" . markdown-mode))
 
 
 ;;; GitHub Flavored Markdown Mode  ============================================

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -179,6 +179,17 @@ Extracts region from BEGIN to END and inserts in OUTPUT-BUFFER."
   (interactive)
   (ert "markdown"))
 
+;;; major-mode tests:
+
+(ert-deftest test-markdown-major-mode ()
+  "Test auto-mode-alist setting."
+  (dolist (extension '(".md" ".markdown" ".mkd" ".mdown" ".mkdn" ".mdwn"))
+    (let ((file (make-temp-file "a" nil extension)))
+      (unwind-protect
+          (with-current-buffer (find-file-noselect file)
+            (should (eq major-mode 'markdown-mode)))
+        (delete-file file)))))
+
 ;;; Example tests:
 
 (ert-deftest test-markdown-example/string ()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

Support `mkd`, `mdown`, `mkdn`, `mdwn` newly.

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#417

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Improvement (non-breaking change which improves an existing feature)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
