### PR TITLE
Fix not consider markdown-list-indent-width issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -131,6 +131,7 @@
     -   Fix wrong italic highlighting in HTML attributes. ([GH-410][])
     -   Fix markdown-follow-thing-at-point issue for continuous links. ([GH-305][])
     -   Fix wrong setting major-mode issue at following wiki link([GH-427][])
+    -   Fix not consider `markdown-list-indent-width` issue([GH-405][])
 
   [gh-349]: https://github.com/jrblevin/markdown-mode/issues/349]
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171
@@ -184,8 +185,9 @@
   [gh-350]: https://github.com/jrblevin/markdown-mode/pull/350
   [gh-369]: https://github.com/jrblevin/markdown-mode/pull/369
   [gh-378]: https://github.com/jrblevin/markdown-mode/pull/378
+  [gh-405]: https://github.com/jrblevin/markdown-mode/issues/405
   [gh-410]: https://github.com/jrblevin/markdown-mode/issues/410
-  [gh-410]: https://github.com/jrblevin/markdown-mode/issues/427
+  [gh-427]: https://github.com/jrblevin/markdown-mode/issues/427
   [gh-437]: https://github.com/jrblevin/markdown-mode/issues/437
 
 # Markdown Mode 2.3

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2542,6 +2542,27 @@ Test currently fails because this case isn't handled properly."
      (should (looking-at "[*+-]"))
      (markdown-test-range-has-face loc loc 'markdown-list-face))))
 
+(ert-deftest test-markdown-font-lock/lists-2 ()
+  "Test markdown-list-face with markdown-list-indent-width.
+See https://github.com/jrblevin/markdown-mode/issues/405 ."
+  (let ((markdown-list-indent-width 2))
+    (markdown-test-string "
+* level 1
+  * level 2
+    * level 3
+      * level 4
+        * level 5"
+      (markdown-test-range-has-face 62 62 'markdown-list-face)))
+
+  (let ((markdown-list-indent-width 4))
+    (markdown-test-string "
+* level 1
+  * level 2
+    * level 3
+      * level 4
+        * level 5"
+      (markdown-test-range-has-face 62 62 nil))))
+
 (ert-deftest test-markdown-font-lock/definition-list ()
   "A simple definition list marker font lock test."
   (markdown-test-file "definition-list.text"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

Some list indent size are hard-coded. It should be replaced with `markdown-list-indent-width`.

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#405

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
