### PR TITLE
Drop Emacs 24.x and X-Emacs support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,6 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 24.4
-          - 24.5
           - 25.1
           - 25.2
           - 25.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,7 @@
 
 *   **Breaking changes:**
 
-    -   GNU Emacs 24.4 or later is required.  Support for Emacs 24.3
-        has been dropped.
+    -   GNU Emacs 25.1 or later is required. And xemacs support has been dropped
     -   Face variables, such as `markdown-italic-face` are now
         obsolete.  Use face names directly in code and customizations.
         The face names themselves are unaffected, so this shouldn't

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3940,7 +3940,7 @@ puts 'hello, world'
   "Test that buttons in unused references buffer delete lines when pushed."
   (markdown-test-file "refs.text"
    (let* ((target (buffer-name))
-          (check (markdown-replace-regexp-in-string
+          (check (replace-regexp-in-string
                   "%buffer%" target
                   markdown-unused-references-buffer))
           (original-unused-refs (markdown-get-unused-refs)))
@@ -5635,7 +5635,7 @@ See GH-288."
    (transient-mark-mode)
    (push-mark (point) t t)
    (end-of-line)
-   (should (markdown-use-region-p))
+   (should (use-region-p))
    (markdown-insert-gfm-code-block "elisp")
    (should (string-equal (buffer-string)
                          "line 1\n\n``` elisp\nline 2\n```\n\nline 3\n"))))
@@ -5657,7 +5657,7 @@ See GH-288."
       (forward-line)
       (push-mark nil :nomsg :activate)
       (end-of-line)
-      (should (markdown-use-region-p))
+      (should (use-region-p))
       (markdown-insert-gfm-code-block "elisp"))
     (should (equal (buffer-substring-no-properties (point-min) (point-max))
                    "1.  foo\n\n    ``` elisp\n    bar\n    ```\n\n"))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

Drop older Emacs support 24.4 and X-Emacs. It makes maintaining hard. I suppose almost all people does not use such older versions.

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
