### PR TITLE
Fix cleanup list number issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -138,6 +138,7 @@
     -   Fix not consider `markdown-list-indent-width` issue([GH-405][])
     -   Fix URL open issue which contains end parentheses ([GH-408][])
     -   Follow link even if it is in header([GH-430][])
+    -   Fix clean up list number issue([GH-392][])
 
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171
   [gh-216]: https://github.com/jrblevin/markdown-mode/issues/216
@@ -191,6 +192,7 @@
   [gh-350]: https://github.com/jrblevin/markdown-mode/pull/350
   [gh-369]: https://github.com/jrblevin/markdown-mode/pull/369
   [gh-378]: https://github.com/jrblevin/markdown-mode/pull/378
+  [gh-392]: https://github.com/jrblevin/markdown-mode/pull/392
   [gh-405]: https://github.com/jrblevin/markdown-mode/issues/405
   [gh-406]: https://github.com/jrblevin/markdown-mode/issues/406
   [gh-408]: https://github.com/jrblevin/markdown-mode/issues/408

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -4220,6 +4220,23 @@ puts 'hello, world'
     (should (string-equal (markdown-toggle-gfm-checkbox) "[x]"))
     (should (string-equal (buffer-string) "   -   [x] GFM task list item"))))
 
+(ert-deftest test-markdown-lists/clean-list-numbers ()
+  "Test for `markdown-cleanup-list-numbers'.
+Detail: https://github.com/jrblevin/markdown-mode/issues/392"
+  (markdown-test-string "Shortcuts
+---------
+  2. Horizontal rule: `C-c C-s -`
+  3. Underlined header `C-c C-s !`
+ 10. Convert to HTML: `C-c C-c m`
+"
+    (call-interactively #'markdown-cleanup-list-numbers)
+    (forward-line 2)
+    (should (looking-at-p "\\s-+1\\. Horizontal rule"))
+    (forward-line 1)
+    (should (looking-at-p "\\s-+2\\. Underlined header"))
+    (forward-line 1)
+    (should (looking-at-p "\\s-+3\\. Convert to HTML"))))
+
 (ert-deftest test-markdown-lists/beginning-of-list ()
   "Test `markdown-beginning-of-list'."
   (markdown-test-file "lists.text"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

Original implementation considers only indentation size but it should consider both indentation and list marker. For example

```markdown
   1. one
   2. two
  10. ten
```

Indentation of `10. ten` line is different from other lines, however they are same level list.

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#392

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
