### PR TITLE
Improve default markdown-command setting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,7 @@
     -   Improve regular expression matching for inline attributes. ([GH-389][])
     -   If user set `display-buffer-alist` then use `display-buffer`. ([GH-413][])
     -   Add custom variable for opening image. ([GH-383][])
+    -   Improve default `markdown-command` setting
 
 *   Bug fixes:
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -88,7 +88,10 @@ Any changes to the output buffer made by this hook will be saved.")
   :group 'text
   :link '(url-link "https://jblevins.org/projects/markdown-mode/"))
 
-(defcustom markdown-command "markdown"
+(defcustom markdown-command (let ((command (cl-loop for cmd in '("markdown" "pandoc")
+                                                    when (executable-find cmd)
+                                                    return (file-name-nondirectory it))))
+                              (or command "markdown"))
   "Command to run markdown."
   :group 'markdown
   :type '(choice (string :tag "Shell command") function))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

I suppose `pandoc` command is popular than `markdown` command

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Improvement (non-breaking change which improves an existing feature)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] All new and existing tests passed (using `make test`).
