### PR TITLE
Fix bold regexp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -147,6 +147,7 @@
     -   Fix clean up list number issue([GH-392][])
     -   Fix insert markup functions in consective case([GH-283][])
     -   Fix hide markup issue in markdown/gfm-view-mode([GH-468][])
+    -   Fix bold regexp issue([GH-325][])
 
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171
   [gh-216]: https://github.com/jrblevin/markdown-mode/issues/216
@@ -194,6 +195,7 @@
   [gh-319]: https://github.com/jrblevin/markdown-mode/issues/319
   [gh-320]: https://github.com/jrblevin/markdown-mode/pull/320
   [gh-322]: https://github.com/jrblevin/markdown-mode/pull/322
+  [gh-325]: https://github.com/jrblevin/markdown-mode/issues/325
   [gh-327]: https://github.com/jrblevin/markdown-mode/issues/327
   [gh-331]: https://github.com/jrblevin/markdown-mode/issues/331
   [gh-335]: https://github.com/jrblevin/markdown-mode/pull/335

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -751,7 +751,7 @@ Group 2 matches any whitespace and the final newline.")
   "Regular expression for matching list items.")
 
 (defconst markdown-regex-bold
-  "\\(^\\|[^\\]\\)\\(\\([*_]\\{2\\}\\)\\([^ \n\t\\]\\|[^ \n\t]\\(?:.\\|\n[^\n]\\)*?[^\\ ]\\)\\(\\3\\)\\)"
+  "\\(?1:^\\|[^\\]\\)\\(?2:\\(?3:\\*\\*\\|__\\)\\(?4:[^ \n\t\\]\\|[^ \n\t]\\(?:.\\|\n[^\n]\\)*?[^\\ ]\\)\\(?5:\\3\\)\\)"
   "Regular expression for matching bold text.
 Group 1 matches the character before the opening asterisk or
 underscore, if any, ensuring that it is not a backslash escape.

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2375,6 +2375,14 @@ See GH-223."
    (should-not (markdown-range-property-any
                 (point-min) (point-max) 'face '(markdown-bold-face)))))
 
+(ert-deftest test-markdown-font-lock/no-bold-asterisk-and-underscore ()
+  "string wrap with single asterisk and single underscore is not bold.
+Detail: https://github.com/jrblevin/markdown-mode/issues/325"
+  (markdown-test-string
+   "_*bold_* *_bold*_"
+   (should-not (markdown-range-property-any 3 6 'face '(markdown-bold-face)))
+   (should-not (markdown-range-property-any 11 14 'face '(markdown-bold-face)))))
+
 (ert-deftest test-markdown-font-lock/code-in-bold ()
   "Test inline code inside bold."
   (markdown-test-string


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

Original regex treats string which is wrapperd '*' or '_' as bold
even if they are mixed. e.g. `*_str*_`. Fix regexp and it matches
only `**str**` or `__str__`


## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#325

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
