### PR TITLE
Fix highlight link issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -155,6 +155,7 @@
     -   Fix nested block fill-paragraph issue([GH-366][])
     -   Fix table transpose issue with wiki link
     -   Fix indent-region for pre block([GH-228][])
+    -   Fix link highlight issue which contains escaped right bracket([GH-409][])
 
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171
   [gh-216]: https://github.com/jrblevin/markdown-mode/issues/216
@@ -221,6 +222,7 @@
   [gh-405]: https://github.com/jrblevin/markdown-mode/issues/405
   [gh-406]: https://github.com/jrblevin/markdown-mode/issues/406
   [gh-408]: https://github.com/jrblevin/markdown-mode/issues/408
+  [gh-409]: https://github.com/jrblevin/markdown-mode/issues/409
   [gh-410]: https://github.com/jrblevin/markdown-mode/issues/410
   [gh-413]: https://github.com/jrblevin/markdown-mode/issues/413
   [gh-415]: https://github.com/jrblevin/markdown-mode/issues/415

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -632,7 +632,7 @@ This variant of `rx' supports common Markdown named REGEXPS."
   "Regular expression matches HTML comment closing.")
 
 (defconst markdown-regex-link-inline
-  "\\(?1:!\\)?\\(?2:\\[\\)\\(?3:[^]^][^]]*\\|\\)\\(?4:\\]\\)\\(?5:(\\)\\(?6:[^)]*?\\)\\(?:\\s-+\\(?7:\"[^\"]*\"\\)\\)?\\(?8:)\\)"
+  "\\(?1:!\\)?\\(?2:\\[\\)\\(?3:\\^?\\(?:\\\\\\]\\|[^]]\\)*\\|\\)\\(?4:\\]\\)\\(?5:(\\)\\(?6:[^)]*?\\)\\(?:\\s-+\\(?7:\"[^\"]*\"\\)\\)?\\(?8:)\\)"
   "Regular expression for a [text](file) or an image link ![text](file).
 Group 1 matches the leading exclamation point (optional).
 Group 2 matches the opening square bracket.

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2792,6 +2792,16 @@ See <https://github.com/jrblevin/markdown-mode/issues/170>."
       (markdown-test-range-has-face 7 17 'markdown-url-face)
       (markdown-test-range-has-face 18 18 'markdown-markup-face))))
 
+(ert-deftest test-markdown-font-lock/inline-links-with-escaped-bracket ()
+  "Test font lock for inline links with escaped bracket.
+Detail: https://github.com/jrblevin/markdown-mode/issues/409"
+  (markdown-test-string "[run(Class, String \\[\\])](http://foo.com)"
+    (markdown-test-range-has-face 1 1 'markdown-markup-face)
+    (markdown-test-range-has-face 2 24 'markdown-link-face)
+    (markdown-test-range-has-face 25 26 'markdown-markup-face)
+    (markdown-test-range-has-face 27 40 'markdown-url-face)
+    (markdown-test-range-has-face 41 41 'markdown-markup-face)))
+
 (ert-deftest test-markdown-font-lock/pre-comment ()
   "Test comments inside of a pre block."
   (markdown-test-string "    <!-- pre, not comment -->"


### PR DESCRIPTION
When link text contains escaped right bracket

<!-- Provide a general summary of your changes in the Title above -->

Original implementation

![before](https://user-images.githubusercontent.com/554281/81714928-9306b000-94b2-11ea-8dcc-35492bcc9de8.png)

With this patch

![after](https://user-images.githubusercontent.com/554281/81714922-926e1980-94b2-11ea-86c9-bacb97a12d62.png)

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#409

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
