### PR TITLE
Fix markdown math inline single issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -158,6 +158,7 @@
     -   Fix table transpose issue with wiki link
     -   Fix indent-region for pre block([GH-228][])
     -   Fix link highlight issue which contains escaped right bracket([GH-409][])
+    -   Fix math inline single highlight issue([GH-352][])
 
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171
   [gh-216]: https://github.com/jrblevin/markdown-mode/issues/216
@@ -214,6 +215,7 @@
   [gh-340]: https://github.com/jrblevin/markdown-mode/issues/340
   [gh-349]: https://github.com/jrblevin/markdown-mode/issues/349
   [gh-350]: https://github.com/jrblevin/markdown-mode/pull/350
+  [gh-352]: https://github.com/jrblevin/markdown-mode/issues/352
   [gh-359]: https://github.com/jrblevin/markdown-mode/issues/359
   [gh-366]: https://github.com/jrblevin/markdown-mode/issues/366
   [gh-369]: https://github.com/jrblevin/markdown-mode/pull/369

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2838,6 +2838,11 @@ $..$ or `markdown-regex-math-inline-double' for matching $$..$$."
 
 (defun markdown-match-math-single (last)
   "Match single quoted $..$ math from point to LAST."
+  (when (and markdown-enable-math
+             (not (bolp)) (char-equal (char-after) ?$)
+             (not (char-equal (char-before) ?\\))
+             (not (char-equal (char-before) ?$)))
+    (forward-char -1))
   (markdown-match-math-generic markdown-regex-math-inline-single last))
 
 (defun markdown-match-math-double (last)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5639,6 +5639,19 @@ See GH-288."
       (markdown-test-range-has-face 301 308 nil)
       (markdown-test-range-has-face 310 312 'markdown-math-face))))
 
+(ert-deftest test-markdown-math/math-inline-single ()
+  "Test for math inline single.
+Detail: https://github.com/jrblevin/markdown-mode/issues/352"
+  (let ((markdown-enable-math t))
+    (markdown-test-string "$a$b$c$"
+      (markdown-test-range-has-face 1 1 'markdown-markup-face)
+      (markdown-test-range-has-face 2 2 'markdown-math-face)
+      (markdown-test-range-has-face 3 3 'markdown-markup-face)
+
+      (markdown-test-range-has-face 5 5 'markdown-markup-face)
+      (markdown-test-range-has-face 6 6 'markdown-math-face)
+      (markdown-test-range-has-face 7 7 'markdown-markup-face))))
+
 ;;; Extension: pipe table editing
 
 (ert-deftest test-markdown-table/table-begin-top-of-file ()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

Original

![before](https://user-images.githubusercontent.com/554281/81876906-bc146700-95be-11ea-89cb-e710b384e2f4.png)

With this patch

![after](https://user-images.githubusercontent.com/554281/81876917-c20a4800-95be-11ea-9c13-2d4adc3474cc.png)


## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

https://github.com/jrblevin/markdown-mode/issues/352#issuecomment-409826496

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
