### PR TITLE
Fix math inline double highlight issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -158,7 +158,7 @@
     -   Fix table transpose issue with wiki link
     -   Fix indent-region for pre block([GH-228][])
     -   Fix link highlight issue which contains escaped right bracket([GH-409][])
-    -   Fix math inline single highlight issue([GH-352][])
+    -   Fix math inline single/double highlight issue([GH-352][])
 
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171
   [gh-216]: https://github.com/jrblevin/markdown-mode/issues/216

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2803,7 +2803,7 @@ When FACELESS is non-nil, do not return matches where faces have been applied."
   "Match REGEX from point to LAST.
 REGEX is either `markdown-regex-math-inline-single' for matching
 $..$ or `markdown-regex-math-inline-double' for matching $$..$$."
-  (when (and markdown-enable-math (markdown-match-inline-generic regex last))
+  (when (markdown-match-inline-generic regex last)
     (let ((begin (match-beginning 1)) (end (match-end 1)))
       (prog1
           (if (or (markdown-range-property-any
@@ -2838,20 +2838,29 @@ $..$ or `markdown-regex-math-inline-double' for matching $$..$$."
 
 (defun markdown-match-math-single (last)
   "Match single quoted $..$ math from point to LAST."
-  (when (and markdown-enable-math
-             (not (bolp)) (char-equal (char-after) ?$)
-             (not (char-equal (char-before) ?\\))
-             (not (char-equal (char-before) ?$)))
-    (forward-char -1))
-  (markdown-match-math-generic markdown-regex-math-inline-single last))
+  (when markdown-enable-math
+    (when (and (char-equal (char-after) ?$)
+               (not (bolp))
+               (not (char-equal (char-before) ?\\))
+               (not (char-equal (char-before) ?$)))
+      (forward-char -1))
+    (markdown-match-math-generic markdown-regex-math-inline-single last)))
 
 (defun markdown-match-math-double (last)
   "Match double quoted $$..$$ math from point to LAST."
-  (markdown-match-math-generic markdown-regex-math-inline-double last))
+  (when markdown-enable-math
+    (when (and (char-equal (char-after) ?$)
+               (char-equal (char-after (1+ (point))) ?$)
+               (not (bolp))
+               (not (char-equal (char-before) ?\\))
+               (not (char-equal (char-before) ?$)))
+      (forward-char -1))
+    (markdown-match-math-generic markdown-regex-math-inline-double last)))
 
 (defun markdown-match-math-display (last)
   "Match bracketed display math \[..\] and \\[..\\] from point to LAST."
-  (markdown-match-math-generic markdown-regex-math-display last))
+  (when markdown-enable-math
+    (markdown-match-math-generic markdown-regex-math-display last)))
 
 (defun markdown-match-propertized-text (property last)
   "Match text with PROPERTY from point to LAST.

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5652,6 +5652,18 @@ Detail: https://github.com/jrblevin/markdown-mode/issues/352"
       (markdown-test-range-has-face 6 6 'markdown-math-face)
       (markdown-test-range-has-face 7 7 'markdown-markup-face))))
 
+(ert-deftest test-markdown-math/math-inline-double ()
+  "Test for math inline double. This is similar to #352 issue."
+  (let ((markdown-enable-math t))
+    (markdown-test-string "$$a$$b$$c$$"
+      (markdown-test-range-has-face 1 2 'markdown-markup-face)
+      (markdown-test-range-has-face 3 3 'markdown-math-face)
+      (markdown-test-range-has-face 4 5 'markdown-markup-face)
+
+      (markdown-test-range-has-face 7 8 'markdown-markup-face)
+      (markdown-test-range-has-face 9 9 'markdown-math-face)
+      (markdown-test-range-has-face 10 11 'markdown-markup-face))))
+
 ;;; Extension: pipe table editing
 
 (ert-deftest test-markdown-table/table-begin-top-of-file ()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

Original

![before](https://user-images.githubusercontent.com/554281/81878223-5de98300-95c2-11ea-8e6d-bfeacc3ba302.png)

With this patch

![after](https://user-images.githubusercontent.com/554281/81878229-65a92780-95c2-11ea-90c7-d67cdbb6194d.png)

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

This is similar to #487

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
