### PR TITLE
Fix markdown-table-forward-cell issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -159,6 +159,7 @@
     -   Fix indent-region for pre block([GH-228][])
     -   Fix link highlight issue which contains escaped right bracket([GH-409][])
     -   Fix math inline single/double highlight issue([GH-352][])
+    -   Fix markdown-table-forward-cell escaped vertical bar issue([GH-489][])
 
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171
   [gh-216]: https://github.com/jrblevin/markdown-mode/issues/216
@@ -238,6 +239,7 @@
   [gh-437]: https://github.com/jrblevin/markdown-mode/issues/437
   [gh-451]: https://github.com/jrblevin/markdown-mode/issues/451
   [gh-468]: https://github.com/jrblevin/markdown-mode/issues/468
+  [gh-489]: https://github.com/jrblevin/markdown-mode/issues/489
 
 # Markdown Mode 2.3
 

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5758,7 +5758,8 @@ Details: https://github.com/jrblevin/markdown-mode/issues/308"
   (should (equal (markdown--table-line-to-columns "|foo|bar|") '("foo" "bar")))
   (should (equal (markdown--table-line-to-columns "  |  foo  |  bar  |  ") '("foo" "bar")))
   (should (equal (markdown--table-line-to-columns "foo|bar") '("foo" "bar")))
-  (should (equal (markdown--table-line-to-columns "foo | bar | baz") '("foo" "bar" "baz"))))
+  (should (equal (markdown--table-line-to-columns "foo | bar | baz") '("foo" "bar" "baz")))
+  (should (equal (markdown--table-line-to-columns "| x \\| |") '("x \\|"))))
 
 (ert-deftest test-markdown-table/blank-line ()
   "Test for creating new blank line."
@@ -5816,6 +5817,20 @@ Detail: https://github.com/jrblevin/markdown-mode/commit/44a1c5bbc5d9514e97c7cc0
                (buffer-substring-no-properties (point-min) (point-max))
                "| A | [[Page|Address]] |
 | B | Content          |
+")))))
+
+(ert-deftest test-markdown-table/forward-cell-with-escaped-vertical-bar ()
+  "Test for table forward-cell with escaped vertical bar.
+Detail: https://github.com/jrblevin/markdown-mode/issues/489"
+  (let ((markdown-enable-wiki-links t))
+    (markdown-test-string "| x \\| |
+"
+      (forward-char 1)
+      (markdown-table-forward-cell)
+      (should (string=
+               (buffer-substring-no-properties (point-min) (point-max))
+               "| x \\| |
+|      |
 ")))))
 
 ;;; gfm-mode tests:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

It did not work well if cell contains escaped vertical bar

Original

![before](https://user-images.githubusercontent.com/554281/82133826-50830180-982b-11ea-913a-543691864d6c.gif)

With this patch

![after](https://user-images.githubusercontent.com/554281/82133831-5842a600-982b-11ea-8623-5283a1a171ef.gif)

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#489 

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
