### PR TITLE
Fix markdown-table-backward-cell issue with escaped vertical bar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,7 @@
     -   Fix link highlight issue which contains escaped right bracket([GH-409][])
     -   Fix math inline single/double highlight issue([GH-352][])
     -   Fix markdown-table-forward-cell escaped vertical bar issue([GH-489][])
+    -   Fix markdown-table-backward-cell escaped vertical bar issue
 
   [gh-171]: https://github.com/jrblevin/markdown-mode/issues/171
   [gh-216]: https://github.com/jrblevin/markdown-mode/issues/216

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9067,11 +9067,11 @@ Create new table lines if required."
   (when (markdown-table-hline-at-point-p) (end-of-line 1))
   (condition-case nil
       (progn
-        (re-search-backward "|" (markdown-table-begin))
-        (re-search-backward "|" (markdown-table-begin)))
+        (re-search-backward "\\(?:^\\|[^\\]\\)|" (markdown-table-begin))
+        (re-search-backward "\\(?:^\\|[^\\]\\)|" (markdown-table-begin)))
     (error (user-error "Cannot move to previous table cell")))
   (while (looking-at "|\\([-:]\\|[ \t]*$\\)")
-    (re-search-backward "|" (markdown-table-begin)))
+    (re-search-backward "\\(?:^\\|[^\\]\\)|" (markdown-table-begin)))
   (when (looking-at "| ?") (goto-char (match-end 0))))
 
 (defun markdown-table-transpose ()

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5822,16 +5822,23 @@ Detail: https://github.com/jrblevin/markdown-mode/commit/44a1c5bbc5d9514e97c7cc0
 (ert-deftest test-markdown-table/forward-cell-with-escaped-vertical-bar ()
   "Test for table forward-cell with escaped vertical bar.
 Detail: https://github.com/jrblevin/markdown-mode/issues/489"
-  (let ((markdown-enable-wiki-links t))
-    (markdown-test-string "| x \\| |
+  (markdown-test-string "| x \\| |
 "
-      (forward-char 1)
-      (markdown-table-forward-cell)
-      (should (string=
-               (buffer-substring-no-properties (point-min) (point-max))
-               "| x \\| |
+    (forward-char 1)
+    (markdown-table-forward-cell)
+    (should (string=
+             (buffer-substring-no-properties (point-min) (point-max))
+             "| x \\| |
 |      |
-")))))
+"))))
+
+(ert-deftest test-markdown-table/backward-cell-with-escaped-vertical-bar ()
+  "Test for table backward-cell with escaped vertical bar."
+  (markdown-test-string "| x \\| |   |"
+    (goto-char (point-max))
+    (backward-char 1)
+    (markdown-table-backward-cell)
+    (should (char-equal (char-after) ?x))))
 
 ;;; gfm-mode tests:
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#490

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
