### PR TITLE
Provide filter-buffer-substring-function in gfm-view-mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -106,6 +106,8 @@
     -   Support list of strings of `markdown-command`
     -   Apply `markdown-translate-filename-function` for `markdown-display-inline-images`
         ([GH-422][])
+    -   Buffer substring filter function which filter out codeblock markers
+        is provided by the `gfm-view-mode`
 
 *   Bug fixes:
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9517,11 +9517,22 @@ rows and columns and the column alignment."
   markdown-view-mode-map
   "Keymap for `gfm-view-mode'.")
 
+(defun gfm-view-mode-filter-function (start end &optional delete)
+  "Remove code block markers from buffer substring between START and END.
+If DELETE is non-nil, delete the text between START and END from the buffer.
+This function is used as value of the `filter-buffer-substring-function'."
+  (prog1 (replace-regexp-in-string "^[[:blank:]]*```.*\n*" ""
+                                   (buffer-substring start end))
+    (when delete
+      (let ((inhibit-read-only t))
+        (delete-region start end)))))
+
 ;;;###autoload
 (define-derived-mode gfm-view-mode gfm-mode "GFM-View"
   "Major mode for viewing GitHub Flavored Markdown content."
   (setq-local markdown-hide-markup markdown-hide-markup-in-view-modes)
   (setq-local markdown-fontify-code-blocks-natively t)
+  (setq-local filter-buffer-substring-function #'gfm-view-mode-filter-function)
   (add-to-invisibility-spec 'markdown-markup)
   (read-only-mode 1))
 

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -91,6 +91,12 @@
   `(markdown-test-file-mode 'gfm-mode ,file ,@body))
 (def-edebug-spec markdown-test-file-gfm (form body))
 
+(defmacro markdown-test-file-gfm-view (file &rest body)
+  "Open FILE from `markdown-test-dir' in `gfm-view-mode' and execute BODY."
+  (declare (indent 1))
+  `(markdown-test-file-mode 'gfm-view-mode ,file ,@body))
+(def-edebug-spec markdown-test-file-gfm-view (form body))
+
 (defmacro markdown-test-temp-file (file &rest body)
   "Open FILE from `markdown-test-dir' visiting temp file and execute BODY.
 This file is not saved."
@@ -2101,6 +2107,13 @@ See GH-245."
       (markdown-test-range-has-property 154 156 'invisible 'markdown-markup)
       (should (invisible-p 154))
       (should (invisible-p 156)))))
+
+(ert-deftest test-markdown-markup-hiding/gfm-filter-buffer-string ()
+  "Test code block markers filtered out when using `filter-buffer-substring'."
+  (let ((markdown-hide-markuo t))
+    (markdown-test-file-gfm-view "GFM.md"
+      (should (not (string-match markdown-regex-gfm-code-block-open
+                                 (filter-buffer-substring (point-min) (point-max))))))))
 
 ;;; Font lock tests:
 


### PR DESCRIPTION
## Description

`gfm-view-mode` is used by [eglot](https://github.com/joaotavora/eglot) to show symbol information in markdown format. E.g. the LSP server send something like this as the documentation:

<pre>
```python
foo(bar=None):
```

```
Docstring for foo
```
</pre>

`eglot-help-at-point` will show this text nicely fontified by `gfm-view-mode`.

The first line (which usually is the signature info) of that text is also used as the eldoc message to show in the echo area. The problem is that the first line is actually invisible codeblock marker.

This PR provides the function that return buffer substring without codeblock markers and can be used as value of the `filter-buffer-substring-function` variable. This way fontified signature info can be shown in the echo area.

Similar behavior is used by the `diff-mode` and the `backtrace-mode`.

Thanks!

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
