### PR TITLE
Implement filter-buffer-substring-function for view-mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -106,6 +106,8 @@
     -   Support list of strings of `markdown-command`
     -   Apply `markdown-translate-filename-function` for `markdown-display-inline-images`
         ([GH-422][])
+    -   Implement own `filter-buffer-substring-function` for `markdown-view-mode` and
+        `gfm-view-mode` ([GH-493][])
 
 *   Bug fixes:
 
@@ -245,6 +247,7 @@
   [gh-451]: https://github.com/jrblevin/markdown-mode/issues/451
   [gh-468]: https://github.com/jrblevin/markdown-mode/issues/468
   [gh-489]: https://github.com/jrblevin/markdown-mode/issues/489
+  [gh-493]: https://github.com/jrblevin/markdown-mode/pull/493
 
 # Markdown Mode 2.3
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

This improves #493 changes
- apply `filter-buffer-substring-function` setting both `markdown-view-mode` and `gfm-view-mode`
- filter not only code block but also any invisible characters

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#493

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
