### PR TITLE
Improve triple backtick behavior with electric-pair-mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,7 @@
         ([GH-422][])
     -   Implement own `filter-buffer-substring-function` for `markdown-view-mode` and
         `gfm-view-mode` ([GH-493][])
+    -   Improve triple backtick behavior with `electric-pair-mode`
 
 *   Bug fixes:
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -46,6 +46,7 @@
 (defvar jit-lock-start)
 (defvar jit-lock-end)
 (defvar flyspell-generic-check-word-predicate)
+(defvar electric-pair-pairs)
 
 
 ;;; Constants =================================================================
@@ -9486,6 +9487,17 @@ rows and columns and the column alignment."
 
 ;;; GitHub Flavored Markdown Mode  ============================================
 
+(defun gfm--electric-pair-fence-code-block ()
+  (when (and electric-pair-mode
+             (not markdown-gfm-use-electric-backquote)
+             (eql last-command-event ?`)
+             (let ((count 0))
+               (while (eql (char-before (- (point) count)) ?`)
+                 (cl-incf count))
+               (= count 3))
+             (eql (char-after) ?`))
+    (save-excursion (insert (make-string 2 ?`)))))
+
 (defvar gfm-mode-hook nil
   "Hook run when entering GFM mode.")
 
@@ -9495,6 +9507,7 @@ rows and columns and the column alignment."
   (setq markdown-link-space-sub-char "-")
   (setq markdown-wiki-link-search-subdirectories t)
   (setq-local markdown-table-at-point-p-function 'gfm--table-at-point-p)
+  (add-hook 'post-self-insert-hook #'gfm--electric-pair-fence-code-block 'append t)
   (markdown-gfm-parse-buffer-for-languages))
 
 

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -32,6 +32,8 @@
 (require 'ert)
 (require 'cl-lib)
 
+(defvar electric-pair-pairs)
+
 (defconst markdown-test-dir
   (expand-file-name (file-name-directory
                      (or load-file-name buffer-file-name))))
@@ -6413,6 +6415,21 @@ foo(bar=None)
 
     (markdown-test-string-gfm-view test-string
       (funcall test-func))))
+
+;;; Tests for electric pair
+
+(ert-deftest test-markdown-electric-pair-mode ()
+  "Test ‘markdown-open’ with ‘markdown-open-command’ being a function."
+  (markdown-test-string-gfm ""
+    (let ((markdown-gfm-use-electric-backquote nil))
+      (electric-pair-local-mode +1)
+      (make-local-variable 'electric-pair-pairs)
+      (add-to-list 'electric-pair-pairs '(?` . ?`))
+      (dotimes (_ 3)
+        (let ((last-command-event ?`))
+          (call-interactively (key-binding `[,last-command-event]))))
+      (should (looking-back "```" (line-beginning-position)))
+      (should (looking-at-p "```")))))
 
 (provide 'markdown-test)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

With following configuration

```lisp
(setq markdown-gfm-use-electric-backquote nil)
(add-hook 'gfm-mode-hook (lambda ()
                           (electric-pair-local-mode 1)
                           (make-local-variable 'electric-pair-pairs)
                           (add-to-list 'electric-pair-pairs '(?` . ?`))))
```

#### Original Implementation

Type triple backticks then insert 4 backticks(Left side: 3, Right side: 1)

![before](https://user-images.githubusercontent.com/554281/83156048-e3317380-a13c-11ea-892e-619dd6563088.gif)

#### This PR version

Type triple backticks then insert 6 backticks as expected(Left side: 3, Right side: 3)

![after](https://user-images.githubusercontent.com/554281/83156066-e9bfeb00-a13c-11ea-9076-51d618d572db.gif)

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Improvement (non-breaking change which improves an existing feature)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
