### PR TITLE
Introduce markdown-mouse-follow-link custom variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,11 +5,14 @@
 *   **Breaking changes:**
 
 *   New features:
+    -   Introduce `markdown-mouse-follow-link` variable [GH-290][]
 
 *   Improvements:
     -   Cleanup test code
 
 *   Bug fixes:
+
+  [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
 
 # Markdown Mode 2.4
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -587,6 +587,14 @@ requires Emacs to be built with ImageMagick support."
                 (choice (sexp :tag "Maximum height in pixels")
                         (const :tag "No maximum height" nil)))))
 
+(defcustom markdown-mouse-follow-link t
+  "Non-nil means mouse on a link will follow the link.
+This variable must be set before loading markdown-mode."
+  :group 'markdown
+  :type 'bool
+  :safe 'booleanp
+  :package-version '(markdown-mode . "2.5"))
+
 
 ;;; Markdown-Specific `rx' Macro ==============================================
 
@@ -5257,10 +5265,11 @@ Assumes match data is available for `markdown-regex-italic'."
   "Keymap for Markdown major mode.")
 
 (defvar markdown-mode-mouse-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map [follow-link] 'mouse-face)
-    (define-key map [mouse-2] #'markdown-follow-thing-at-point)
-    map)
+  (when markdown-mouse-follow-link
+    (let ((map (make-sparse-keymap)))
+      (define-key map [follow-link] 'mouse-face)
+      (define-key map [mouse-2] #'markdown-follow-thing-at-point)
+      map))
   "Keymap for following links with mouse.")
 
 (defvar gfm-mode-map


### PR DESCRIPTION
This is inspired by org-mouse-1-follows-link in org-mode.
This must be set before loading markdown-mode.

<!-- Provide a general summary of your changes in the Title above -->

Sample configuration

```lisp
(custom-set-variables
 '(markdown-mouse-follow-link nil))
```

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#290

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
