### PR TITLE
Skip tests that invoke ‘pandoc’ if that isn’t installed

### DIFF
--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -6317,6 +6317,7 @@ https://github.com/jrblevin/markdown-mode/issues/235"
 
 (ert-deftest test-markdown-command/string-command ()
   "Test `markdown-command' for string which has only command."
+  (skip-unless (executable-find "pandoc"))
   (markdown-test-string "foo"
     (let ((markdown-command "pandoc"))
       ;; check exception is not thrown
@@ -6324,12 +6325,14 @@ https://github.com/jrblevin/markdown-mode/issues/235"
 
 (ert-deftest test-markdown-command/string-command-with-options ()
   "Test `markdown-command' for string which has command and options."
+  (skip-unless (executable-find "pandoc"))
   (markdown-test-string "foo"
     (let ((markdown-command "pandoc --from=markdown --to=html5"))
       (should (markdown)))))
 
 (ert-deftest test-markdown-command/list-of-strings ()
   "Test `markdown-command' for list of strings."
+  (skip-unless (executable-find "pandoc"))
   (markdown-test-string "foo"
     (let ((markdown-command '("pandoc" "--from=markdown" "--to=html5")))
       (should (markdown)))))


### PR DESCRIPTION
## Description

Skip tests that can't succeed because 'pandoc' isn't installed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
