### PR TITLE
Make interactive detection in ‘markdown-up-heading’ less brittle.

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -6586,12 +6586,13 @@ Stop at the first and last headings of a superior heading."
             (setq arg (1- arg)))
         (user-error "No previous same-level heading")))))
 
-(defun markdown-up-heading (arg)
+(defun markdown-up-heading (arg &optional interactive)
   "Move to the visible heading line of which the present line is a subheading.
-With argument, move up ARG levels."
-  (interactive "p")
-  (and (called-interactively-p 'any)
-       (not (eq last-command 'markdown-up-heading)) (push-mark))
+With argument, move up ARG levels.  When called interactively (or
+INTERACTIVE is non-nil), also push the mark."
+  (interactive "p\np")
+  (and interactive (not (eq last-command 'markdown-up-heading))
+       (push-mark))
   (markdown-move-heading-common #'outline-up-heading arg 'adjust))
 
 (defun markdown-back-to-heading (&optional invisible-ok)


### PR DESCRIPTION
## Description

See the docstring of ‘called-interactively-p’.

In particular, this makes the test ‘test-markdown-outline/navigation’ pass if
‘markdown-up-heading’ is instrumented using Edebug.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
