### PR TITLE
Fix inline URL regexp which starts/ends with spaces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,10 +13,12 @@
 
 *   Bug fixes:
     -   Fix remaining flyspell overlay in code block or comment issue[GH-311][]
+    -   Fix inline URL regular expression which starts/ends with spaces[GH-514][]
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311
   [gh-511]: https://github.com/jrblevin/markdown-mode/issues/511
+  [gh-514]: https://github.com/jrblevin/markdown-mode/issues/514
 
 # Markdown Mode 2.4
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -641,7 +641,7 @@ This variant of `rx' supports common Markdown named REGEXPS."
   "Regular expression matches HTML comment closing.")
 
 (defconst markdown-regex-link-inline
-  "\\(?1:!\\)?\\(?2:\\[\\)\\(?3:\\^?\\(?:\\\\\\]\\|[^]]\\)*\\|\\)\\(?4:\\]\\)\\(?5:(\\)\\(?6:[^)]*?\\)\\(?:\\s-+\\(?7:\"[^\"]*\"\\)\\)?\\(?8:)\\)"
+  "\\(?1:!\\)?\\(?2:\\[\\)\\(?3:\\^?\\(?:\\\\\\]\\|[^]]\\)*\\|\\)\\(?4:\\]\\)\\(?5:(\\)\\s-*\\(?6:[^)]*?\\)\\(?:\\s-+\\(?7:\"[^\"]*\"\\)\\)?\\s-*\\(?8:)\\)"
   "Regular expression for a [text](file) or an image link ![text](file).
 Group 1 matches the leading exclamation point (optional).
 Group 2 matches the opening square bracket.

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -4950,6 +4950,22 @@ Detail: https://github.com/jrblevin/markdown-mode/issues/408"
       (let ((link (markdown-link-at-pos (point))))
         (should (string= (nth 3 link) url))))))
 
+(ert-deftest test-markdown-link/start-or-end-with-spaces ()
+  "Test `markdown-link-at-pos' return values with URL part starts/ends with spaces.
+Detail: https://github.com/jrblevin/markdown-mode/issues/514"
+  (markdown-test-string "[Broken](
+http://example.com  )
+"
+    (let ((values (markdown-link-at-pos (point))))
+      (should (string= (nth 3 values) "http://example.com"))))
+
+  (markdown-test-string "[Broken](
+http://example.com \"title\"  )
+"
+    (let ((values (markdown-link-at-pos (point))))
+      (should (string= (nth 3 values) "http://example.com"))
+      (should (string= (nth 5 values) "title")))))
+
 (ert-deftest test-markdown-link/follow-filename ()
   "Test that `markdown-follow-thing-at-pos' uses
 `markdown-translate-filename-function' to translate filenames."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#514 @cpcallen

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
