### PR TITLE
Fix fontification of YAML and TOML metadata

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -905,7 +905,7 @@ Group 5 matches the closing brace (optional) and any surrounding whitespace.
 Groups need to agree with `markdown-regex-gfm-code-block-open'.")
 
 (defconst markdown-regex-declarative-metadata
-  "^\\([[:alpha:]][[:alpha:] _-]*?\\)\\([:=][ \t]*\\)\\(.*\\)$"
+  "^[ \t]*\\([[:alpha:]][[:alpha:] _-]*?\\)\\([:=][ \t]*\\)\\(.*\\)$"
   "Regular expression for matching declarative metadata statements.
 This matches MultiMarkdown metadata as well as YAML and TOML
 assignments such as the following:


### PR DESCRIPTION
Fix fontification of YAML and TOML metadata indented using tabs and/or spaces.

## Description

Since both YAML and TOML metadata statements can be indented using tabs and/or spaces (common in YAML to indicate nesting, allowed, but not required in TOML), the regexp `markdown-regex-declarative-metadata` is modified to allow tabs and/or spaces at BOL.

## Related Issue

This commit should fix #476.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
