### PR TITLE
Improve fontification of sub- and superscript

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -953,7 +953,7 @@ Compatible with Pandoc, Python Markdown, PHP Markdown Extra, and Leanpub.")
   "Regular expression for Leanpub section markers and related syntax.")
 
 (defconst markdown-regex-sub-superscript
-  "\\(?:^\\|[^\\~^]\\)\\(?1:\\(?2:[~^]\\)\\(?3:[[:alnum:]]+\\)\\(?4:\\2\\)\\)"
+  "\\(?:^\\|[^\\~^]\\)\\(?1:\\(?2:[~^]\\)\\(?3:\\(?:\\\\.\\|[^[:space:]]\\)+\\)\\(?4:\\2\\)\\)"
   "The regular expression matching a sub- or superscript.
 The leading un-numbered group matches the character before the
 opening tilde or carat, if any, ensuring that it is not a


### PR DESCRIPTION
Improve fontification of sub- and superscript expressions

## Description

Limiting sub- and superscript expressions to only alphanumerical characters is too restrictive. Now sub- and superscript expressions can contain backslash-escaped spaces, punctuation marks, and other symbols, accrording to Pandoc syntax: <http://pandoc.org/MANUAL.html#superscripts-and-subscripts>.

## Related Issue

This commit should close #346.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
