### PR TITLE
Fix italic fontification for one character in gfm-mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,8 +14,9 @@
     -   Improve fontification for nested meta data [GH-476][]
 
 *   Bug fixes:
-    -   Fix remaining flyspell overlay in code block or comment issue[GH-311][]
-    -   Fix inline URL regular expression which starts/ends with spaces[GH-514][]
+    -   Fix remaining flyspell overlay in code block or comment issue [GH-311][]
+    -   Fix inline URL regular expression which starts/ends with spaces [GH-514][]
+    -   Fix GFM italic fontification for one character [GH-524][]
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311
@@ -23,6 +24,7 @@
   [gh-511]: https://github.com/jrblevin/markdown-mode/issues/511
   [gh-514]: https://github.com/jrblevin/markdown-mode/issues/514
   [gh-517]: https://github.com/jrblevin/markdown-mode/issues/517
+  [gh-524]: https://github.com/jrblevin/markdown-mode/issues/524
 
 # Markdown Mode 2.4
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -789,7 +789,7 @@ Groups 3 and 5 matches the opening and closing delimiters.
 Group 4 matches the text inside the delimiters.")
 
 (defconst markdown-regex-gfm-italic
-  "\\(?:^\\|[^\\]\\)\\(?1:\\(?2:[*_]\\)\\(?3:[^ \\]\\2\\|[^ ]\\(?:.\\|\n[^\n]\\)*?[^\\ ]\\)\\(?4:\\2\\)\\)"
+  "\\(?:^\\|[^\\]\\)\\(?1:\\(?2:[*_]\\)\\(?3:[^ \\]\\2\\|[^ ]\\(?:.\\|\n[^\n]\\)*?\\)\\(?4:\\2\\)\\)"
   "Regular expression for matching italic text in GitHub Flavored Markdown.
 Underscores in words are not treated as special.
 Group 1 matches the entire expression, including delimiters.

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5962,6 +5962,25 @@ no_em ph_asis
     (markdown-test-range-has-face 97 104 nil)
     (markdown-test-range-has-face 110 114 nil)))
 
+(ert-deftest test-markdown-gfm/italic-underscore-one-character ()
+  "Test for GFM italic font lock test for one character.
+Details: https://github.com/jrblevin/markdown-mode/issues/524"
+  (markdown-test-string-gfm "*a* other text *abc*"
+    (markdown-test-range-has-face 3 3 'markdown-markup-face)
+    (markdown-test-range-has-face 4 15 nil)
+    (markdown-test-range-has-face 16 16 'markdown-markup-face)
+    (markdown-test-range-has-face 17 19 'markdown-italic-face)
+    (markdown-test-range-has-face 20 20 'markdown-markup-face))
+
+  (markdown-test-string-gfm "*a* _b_"
+    (markdown-test-range-has-face 1 1 'markdown-markup-face)
+    (markdown-test-range-has-face 2 2 'markdown-italic-face)
+    (markdown-test-range-has-face 3 3 'markdown-markup-face)
+    (markdown-test-range-has-face 4 4 nil)
+    (markdown-test-range-has-face 5 5 'markdown-markup-face)
+    (markdown-test-range-has-face 6 6 'markdown-italic-face)
+    (markdown-test-range-has-face 7 7 'markdown-markup-face)))
+
 (ert-deftest test-markdown-gfm/strike-through-1 ()
   "GFM strike through font lock test."
   (markdown-test-string-gfm "one ~~two~~ three"


### PR DESCRIPTION
## Description

#### Original code

![before](https://user-images.githubusercontent.com/554281/90200922-52e9fd00-de14-11ea-8dda-9c79808c56e0.png)

#### With this patch

![after](https://user-images.githubusercontent.com/554281/90200936-59787480-de14-11ea-9632-e1d5614ef792.png)

## Related Issue

#524 CC: @rriegs

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
