### PR TITLE
Fix regular expression for searching next table row

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
     -   Fix remaining flyspell overlay in code block or comment issue [GH-311][]
     -   Fix inline URL regular expression which starts/ends with spaces [GH-514][]
     -   Fix GFM italic fontification for one character [GH-524][]
+    -   Fix `markdown-table-forward-cell` at last column issue [GH-522][]
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311
@@ -24,6 +25,7 @@
   [gh-511]: https://github.com/jrblevin/markdown-mode/issues/511
   [gh-514]: https://github.com/jrblevin/markdown-mode/issues/514
   [gh-517]: https://github.com/jrblevin/markdown-mode/issues/517
+  [gh-522]: https://github.com/jrblevin/markdown-mode/issues/522
   [gh-524]: https://github.com/jrblevin/markdown-mode/issues/524
 
 # Markdown Mode 2.4

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9091,7 +9091,7 @@ Create new table lines if required."
         (progn
           (re-search-forward "\\(?:^\\|[^\\]\\)|" end)
           (when (looking-at "[ \t]*$")
-            (re-search-forward "\\(?^|[^\\]:\\)|" end))
+            (re-search-forward "\\(?:^\\|[^\\]:\\)|" end))
           (when (and (looking-at "[-:]")
                      (re-search-forward "^\\(?:[ \t]*\\|[^\\]\\)|\\([^-:]\\)" end t))
             (goto-char (match-beginning 1)))

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5910,6 +5910,21 @@ Detail: https://github.com/jrblevin/markdown-mode/issues/489"
 |      |
 "))))
 
+(ert-deftest test-markdown-table/forward-cell-at-last-column ()
+  "Test for table forward-cell at last column.
+Detail: https://github.com/jrblevin/markdown-mode/issues/522"
+  (markdown-test-string "| one  | two  |
+| three | four |
+"
+    (search-forward "two")
+    (markdown-table-forward-cell)
+    (should (string= (thing-at-point 'word) "three"))
+    (markdown-table-forward-cell)
+    (should (string= (thing-at-point 'word) "four"))
+    (markdown-table-forward-cell)
+    (should (string= (buffer-substring-no-properties (line-beginning-position) (line-end-position))
+                     "|       |      |"))))
+
 (ert-deftest test-markdown-table/backward-cell-with-escaped-vertical-bar ()
   "Test for table backward-cell with escaped vertical bar."
   (markdown-test-string "| x \\| |   |"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

#### Original code

![before](https://user-images.githubusercontent.com/554281/90246397-85751380-de6f-11ea-91e0-87dd6a6f8fba.gif)

#### With this patch

![after](https://user-images.githubusercontent.com/554281/90246382-8148f600-de6f-11ea-9999-fa17cb3896bf.gif)

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#522 CC: @divansantana 

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
