### PR TITLE
Fix markdown-cycle called with universal-argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
     -   Strip query parameters from local file name at displaying inline images [GH-511][]
     -   Improve forward/backward sentences which are wrapped markup characters [GH-517][]
     -   Improve fontification for nested meta data [GH-476][]
+    -   `markdown-cycle` accpets universal-argument like org-cycle [GH-530][]
 
 *   Bug fixes:
     -   Fix remaining flyspell overlay in code block or comment issue [GH-311][]
@@ -29,6 +30,7 @@
   [gh-522]: https://github.com/jrblevin/markdown-mode/issues/522
   [gh-524]: https://github.com/jrblevin/markdown-mode/issues/524
   [gh-525]: https://github.com/jrblevin/markdown-mode/issues/525
+  [gh-530]: https://github.com/jrblevin/markdown-mode/issues/530
 
 # Markdown Mode 2.4
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -6683,15 +6683,15 @@ setext header, but should not be folded."
 ;; This function was originally derived from `org-cycle' from org.el.
 (defun markdown-cycle (&optional arg)
   "Visibility cycling for Markdown mode.
-If ARG is t, perform global visibility cycling.  If the point is
-at an atx-style header, cycle visibility of the corresponding
-subtree.  Otherwise, indent the current line or insert a tab,
-as appropriate, by calling `indent-for-tab-command'."
+This function is called with a `\\[universal-argument]' or if ARG is t, perform
+global visibility cycling.  If the point is at an atx-style header, cycle
+visibility of thecorresponding subtree.  Otherwise, indent the current line
+ or insert a tab, as appropriate, by calling `indent-for-tab-command'."
   (interactive "P")
   (cond
 
    ;; Global cycling
-   ((eq arg t)
+   (arg
     (cond
      ;; Move from overview to contents
      ((and (eq last-command this-command)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -4544,7 +4544,15 @@ date = 2015-08-13 11:35:25 EST
      (setq this-command 'markdown-cycle)
      (markdown-cycle t)
      ;; Check that text is visible
-     (markdown-test-range-has-property (point-min) (point-max) 'invisible nil))))
+     (markdown-test-range-has-property (point-min) (point-max) 'invisible nil))
+
+   (let (last-command this-command)
+     ;; Cycle global visibility to "overview" mode
+     (setq this-command 'markdown-cycle)
+     (let ((current-prefix-arg '(4)))
+      (markdown-cycle)
+      ;; Check that text is visible
+      (markdown-test-range-has-property (point-min) (point-max) 'invisible nil)))))
 
 (ert-deftest test-markdown-outline/level ()
   "Test `markdown-outline-level'."


### PR DESCRIPTION
This behavior is same as org-cycle

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#530 @jo-so

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Improvement (non-breaking change which improves an existing feature)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
