### PR TITLE
Fix wrong fontification issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
     -   Fix GFM italic fontification for one character [GH-524][]
     -   Fix `markdown-table-forward-cell` at last column issue [GH-522][]
     -   Fix GFM bold fontification with underscore issue [GH-525][]
+    -   Fix wrong fontification words between strong markups [GH-534][]
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311
@@ -33,6 +34,7 @@
   [gh-525]: https://github.com/jrblevin/markdown-mode/issues/525
   [gh-530]: https://github.com/jrblevin/markdown-mode/issues/530
   [gh-532]: https://github.com/jrblevin/markdown-mode/issues/532
+  [gh-534]: https://github.com/jrblevin/markdown-mode/issues/534
 
 # Markdown Mode 2.4
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2818,7 +2818,9 @@ When FACELESS is non-nil, do not return matches where faces have been applied."
                                    markdown-list-face
                                    markdown-hr-face
                                    markdown-math-face))
-                (and is-gfm (not (markdown--gfm-markup-underscore-p begin close-end))))
+                (and is-gfm
+                     (or (char-equal (char-after begin) (char-after (1+ begin))) ;; check bold case
+                         (not (markdown--gfm-markup-underscore-p begin close-end)))))
             (progn (goto-char (min (1+ begin) last))
                    (when (< (point) last)
                      (markdown-match-italic last)))

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -6039,6 +6039,18 @@ no__t str__ong
     (markdown-test-range-has-face 200 206 nil)
     (markdown-test-range-has-face 217 221 nil)))
 
+(ert-deftest test-markdown-gfm/string-between-strong-markup ()
+  "Test for string between strong markup.
+Details: https://github.com/jrblevin/markdown-mode/issues/534"
+  (markdown-test-string-gfm "**foo** and **bar**"
+    (markdown-test-range-has-face 1 2 'markdown-markup-face)
+    (markdown-test-range-has-face 3 5 'markdown-bold-face)
+    (markdown-test-range-has-face 6 7 'markdown-markup-face)
+    (markdown-test-range-has-face 8 12 nil)
+    (markdown-test-range-has-face 13 14 'markdown-markup-face)
+    (markdown-test-range-has-face 15 17 'markdown-bold-face)
+    (markdown-test-range-has-face 18 19 'markdown-markup-face)))
+
 (ert-deftest test-markdown-gfm/strike-through-1 ()
   "GFM strike through font lock test."
   (markdown-test-string-gfm "one ~~two~~ three"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Don't apply italic fontification for words which is between strong markups

<!-- More detailed description of the changes if needed. -->

#### Original

![before](https://user-images.githubusercontent.com/554281/91311365-f9a7a380-e7ed-11ea-914e-133e7e93bfc6.png)

#### With this patch

![after](https://user-images.githubusercontent.com/554281/91311355-f6141c80-e7ed-11ea-8674-a5a57b14163f.png)


## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#534

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
