### PR TITLE
Customizations for insert link

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 *   New features:
     -   Introduce `markdown-mouse-follow-link` variable [GH-290][]
+    -   Option to define a `markdown-link-make-text-function` function
+        to automatically define a default link text before prompting the user.
+    -   Option to inhibit the prompt for a tooltip text via
+        `markdown-disable-tooltip-prompt`.
 
 *   Improvements:
     -   Cleanup test code

--- a/README.md
+++ b/README.md
@@ -224,7 +224,12 @@ can obtain a list of all keybindings by pressing <kbd>C-c C-h</kbd>.
     reference will be inserted according to the value of
     `markdown-reference-location`.  If a title is given, it will be
     added to the end of the reference definition and will be used
-    to populate the title attribute when converted to HTML.
+    to populate the title attribute when converted to HTML.  In addition, it is
+    possible to have the `markdown-link-make-text-function` function, if
+    non-nil, define the default link text before prompting the user for it.
+
+    If `markdown-disable-tooltip-prompt` is non-nil, the user will not be
+    prompted to add or modify a tooltip text.
 
     Images associated with image links may be displayed
     inline in the buffer by pressing <kbd>C-c C-x C-i</kbd>

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -1289,6 +1289,22 @@ Don't adjust spacing if tabs are used as whitespace."
       (should (= (point) 31))
       (transient-mark-mode tmm-orig))))
 
+(ert-deftest test-markdown-insertion/disable-tooltip-prompt ()
+  "Test `markdown-insert-link' with
+`markdown-disable-tooltip-prompt' option t."
+  (markdown-test-string "<https://www.gnu.org/>"
+    (let ((markdown-disable-tooltip-prompt t))
+      (execute-kbd-macro (read-kbd-macro "M-x markdown-insert-link RET RET GNU RET"))
+      (should (string-equal (buffer-string) "[GNU](https://www.gnu.org/)")))))
+
+(ert-deftest test-markdown-insertion/link-make-text-function ()
+  "Test `markdown-insert-link' with custom
+`markdown-link-make-text-function'."
+  (markdown-test-string "<https://www.gnu.org/>"
+    (let ((markdown-link-make-text-function (lambda (url) (ignore url) "GNU")))
+      (execute-kbd-macro (read-kbd-macro "M-x markdown-insert-link RET RET RET RET"))
+      (should (string-equal (buffer-string) "[GNU](https://www.gnu.org/)")))))
+
 ;;; Footnote tests:
 
 (ert-deftest test-markdown-footnote/basic-end ()


### PR DESCRIPTION
## Description

Two new features introduced to customize the behavior of
`markdown--insert-link-or-image`:

1. Option to define a `markdown-link-make-text-function` function that
(intelligently) defines a default link text before prompting the user.
2. Option to inhibit the prompt for a tooltip text via
`markdown-disable-tooltip-prompt`.

The reasoning for (1) is that someone can, for instance, have a function able to parse a webpage title, and then set `markdown-link-make-text-function` to that function to have an automated default link text in the prompt.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
