### PR TITLE
Fix wrong italic fontification just after code block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
     -   Fix `markdown-table-forward-cell` at last column issue [GH-522][]
     -   Fix GFM bold fontification with underscore issue [GH-525][]
     -   Fix wrong fontification words between strong markups [GH-534][]
+    -   Fix wrong italic fontification just after code block [GH-548][]
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311
@@ -43,6 +44,7 @@
   [gh-532]: https://github.com/jrblevin/markdown-mode/issues/532
   [gh-534]: https://github.com/jrblevin/markdown-mode/issues/534
   [gh-536]: https://github.com/jrblevin/markdown-mode/issues/536
+  [gh-548]: https://github.com/jrblevin/markdown-mode/issues/548
 
 # Markdown Mode 2.4
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2635,9 +2635,10 @@ Group 3 matches the closing backquotes."
       (while (and (markdown-match-code end-of-block)
                   (setq found t)
                   (< (match-end 0) old-point)))
-      (and found                              ; matched something
-           (<= (match-beginning 0) old-point) ; match contains old-point
-           (> (match-end 0) old-point)))))
+      (let ((match-group (if (eq (char-after (match-beginning 0)) ?`) 0 1)))
+        (and found                                        ; matched something
+             (<= (match-beginning match-group) old-point) ; match contains old-point
+             (> (match-end 0) old-point))))))
 
 (defun markdown-inline-code-at-pos-p (pos)
   "Return non-nil if there is an inline code fragment at POS.
@@ -2816,7 +2817,7 @@ When FACELESS is non-nil, do not return matches where faces have been applied."
             (close-end (match-end 4)))
         (if (or (eql (char-before begin) (char-after begin))
                 (markdown-inline-code-at-pos-p begin)
-                (markdown-inline-code-at-pos-p end)
+                (markdown-inline-code-at-pos-p (1- end))
                 (markdown-in-comment-p)
                 (markdown-range-property-any
                  begin begin 'face '(markdown-url-face

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2344,6 +2344,19 @@ Detail: https://github.com/jrblevin/markdown-mode/issues/359"
     (markdown-range-property-any 27 32 'face '(markdown-italic-face)))
    (markdown-range-property-any 36 38 'face '(markdown-bold-face))))
 
+(ert-deftest test-markdown-font-lock/italic-after-code-block ()
+  "Test italic fontification after code block.
+Detail: https://github.com/jrblevin/markdown-mode/issues/548"
+  (markdown-test-string "`(`*italic*`)` plain text
+*italic*"
+    (markdown-test-range-has-face 4 4 'markdown-markup-face)
+    (markdown-test-range-has-face 5 10 'markdown-italic-face)
+    (markdown-test-range-has-face 11 11 'markdown-markup-face)
+    (markdown-test-range-has-face 16 25 nil)
+    (markdown-test-range-has-face 27 27 'markdown-markup-face)
+    (markdown-test-range-has-face 28 33 'markdown-italic-face)
+    (markdown-test-range-has-face 34 34 'markdown-markup-face)))
+
 (ert-deftest test-markdown-font-lock/bold-1 ()
   "A simple bold test."
   (markdown-test-file "inline.text"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

### Original Code

![before](https://user-images.githubusercontent.com/554281/95275796-76fe1380-0884-11eb-9a98-8665676f9ad8.png)

### This PR version

![after](https://user-images.githubusercontent.com/554281/95275807-7e252180-0884-11eb-9e8e-7a166ddf0cf7.png)

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#548 (CC: @dabrahams)

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
