### PR TITLE
correct indentation when editing code blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
         `markdown-disable-tooltip-prompt`.
 
 *   Improvements:
+    -   Correct indirect buffer's indentation in `markdown-edit-code-block` [GH-375][]
     -   Cleanup test code
     -   Strip query parameters from local file name at displaying inline images [GH-511][]
     -   Improve forward/backward sentences which are wrapped markup characters [GH-517][]
@@ -32,6 +33,7 @@
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311
+  [gh-375]: https://github.com/jrblevin/markdown-mode/issues/375
   [gh-476]: https://github.com/jrblevin/markdown-mode/issues/476
   [gh-511]: https://github.com/jrblevin/markdown-mode/issues/511
   [gh-512]: https://github.com/jrblevin/markdown-mode/issues/512

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8574,7 +8574,6 @@ position."
 (require 'edit-indirect nil t)
 (defvar edit-indirect-guess-mode-function)
 (defvar edit-indirect-after-commit-functions)
-(defvar edit-indirect-before-commit-hook)
 
 (defun markdown--edit-indirect-after-commit-function (beg end)
   "Corrective logic run on code block content from lines BEG to END.

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8584,7 +8584,8 @@ position."
 
 (defun markdown--edit-indirect-before-commit-hook ()
   "Ensure correct indentation of code block content."
-  (when (boundp 'markdown--code-block-indirect-indentation)
+  (when (and (boundp 'markdown--code-block-indirect-indentation)
+             markdown--code-block-indirect-indentation)
     (indent-rigidly (point-min) (point-max)
                     markdown--code-block-indirect-indentation)))
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8574,7 +8574,7 @@ position."
 (require 'edit-indirect nil t)
 (defvar edit-indirect-guess-mode-function)
 (defvar edit-indirect-after-commit-functions)
-(defvar edit-indirect-before-commit-hook)
+;; (defvar edit-indirect-before-commit-hook)
 
 (defun markdown--edit-indirect-after-commit-function (_beg end)
   "Ensure trailing newlines at the END of code blocks."
@@ -9555,8 +9555,7 @@ rows and columns and the column alignment."
             #'markdown--edit-indirect-after-commit-function
             nil 'local)
   (add-hook 'edit-indirect-before-commit-hook
-            #'markdown--edit-indirect-before-commit-hook
-            nil 'local)
+            #'markdown--edit-indirect-before-commit-hook)
 
   ;; Marginalized headings
   (when markdown-marginalize-headers

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8604,9 +8604,10 @@ position."
                                markdown-edit-code-block-default-mode))
                      (edit-indirect-guess-mode-function
                       (lambda (_parent-buffer _beg _end)
-                        (funcall mode))))
+                        (funcall mode)))
+                     (indirect-buf (edit-indirect-region begin end 'display-buffer)))
                 (when (> indentation 0)
-                  (with-current-buffer (edit-indirect-region begin end 'display-buffer)
+                  (with-current-buffer indirect-buf
                     (setq-local markdown--code-block-indirect-indentation
                                 indentation)
                     (indent-rigidly (point-min) (point-max) (- indentation)))))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8585,7 +8585,6 @@ position."
 (defun markdown--edit-indirect-before-commit-hook ()
   "Ensure correct indentation of code block content."
   (when markdown--code-block-indirect-indentation
-    (print "success!\n")
     (indent-rigidly (point-min) (point-max)
                     markdown--code-block-indirect-indentation)))
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8574,7 +8574,7 @@ position."
 (require 'edit-indirect nil t)
 (defvar edit-indirect-guess-mode-function)
 (defvar edit-indirect-after-commit-functions)
-;; (defvar edit-indirect-before-commit-hook)
+(defvar edit-indirect-before-commit-hook)
 
 (defun markdown--edit-indirect-after-commit-function (_beg end)
   "Ensure trailing newlines at the END of code blocks."
@@ -8607,8 +8607,9 @@ position."
                      (indirect-buf (edit-indirect-region begin end 'display-buffer)))
                 (when (> indentation 0)
                   (with-current-buffer indirect-buf
+                    (defvar markdown--code-block-indirect-indentation)
                     (setq-local markdown--code-block-indirect-indentation
-                                indentation)
+                      indentation)
                     (indent-rigidly (point-min) (point-max) (- indentation)))))
             (user-error "Not inside a GFM or tilde fenced code block")))
       (when (y-or-n-p "Package edit-indirect needed to edit code blocks. Install it now? ")

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8584,7 +8584,7 @@ position."
 
 (defun markdown--edit-indirect-before-commit-hook ()
   "Ensure correct indentation of code block content."
-  (when markdown--code-block-indirect-indentation
+  (when (boundp 'markdown--code-block-indirect-indentation)
     (indent-rigidly (point-min) (point-max)
                     markdown--code-block-indirect-indentation)))
 


### PR DESCRIPTION
Closes #375.

## Description

The goal is to allow indented code blocks to open up without any indentation in the edit-indirect buffer. 

We achieve this by detecting the indentation of the code block in `markdown-edit-code-block`, and de-indenting the content of the edit-indirect buffer if the indentation of the code block is non-zero. Then, in the `edit-indirect-after-commit-function`, we again detect the indentation of the code block and if it's non-0, we apply the indentation back to the file. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
