### PR TITLE
Treat too indented line as list if previous line is list

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1154,7 +1154,8 @@ this property is a list with elements of the form (begin . end)
 giving the bounds of the current and parent list items."
   (save-excursion
     (goto-char start)
-    (let (bounds level pre-regexp)
+    (let ((prev-list-line -100)
+          bounds level pre-regexp)
       ;; Find a baseline point with zero list indentation
       (markdown-search-backward-baseline)
       ;; Search for all list items between baseline and END
@@ -1171,7 +1172,9 @@ giving the bounds of the current and parent list items."
          ((markdown-new-baseline)
           (setq bounds nil))
          ;; Make sure this is not a line from a pre block
-         ((looking-at-p pre-regexp))
+         ((and (looking-at-p pre-regexp)
+               ;; too indented line is also treated as list if previous line is list
+               (>= (- (line-number-at-pos) prev-list-line) 2)))
          ;; If not, then update levels and propertize list item when in range.
          (t
           (let* ((indent (current-indentation))
@@ -1182,6 +1185,7 @@ giving the bounds of the current and parent list items."
             (setq bounds (markdown--append-list-item-bounds
                           marker indent cur-bounds bounds))
           (when (and (<= start (point)) (<= (point) end))
+            (setq prev-list-line (line-number-at-pos first))
             (put-text-property first last 'markdown-list-item bounds)))))
         (end-of-line)))))
 

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2650,16 +2650,21 @@ See https://github.com/jrblevin/markdown-mode/issues/405 ."
     * level 3
       * level 4
         * level 5"
-      (markdown-test-range-has-face 62 62 'markdown-list-face)))
+      (markdown-test-range-has-face 62 62 'markdown-list-face))))
 
-  (let ((markdown-list-indent-width 4))
-    (markdown-test-string "
-* level 1
-  * level 2
-    * level 3
-      * level 4
-        * level 5"
-      (markdown-test-range-has-face 62 62 nil))))
+(ert-deftest test-markdown-font-lock/lists-3 ()
+  "Test markdown-list-face for too intended line.
+Too indented line is also treated as list rf previous line is line
+in Common mark.
+See https://github.com/jrblevin/markdown-mode/issues/569"
+  (markdown-test-string "* [ ] One
+  * [ ] Two
+    * [ ] Three
+      * [ ] Four
+        * [ ] Five
+          * [ ] Six"
+    (markdown-test-range-has-face 64 64 'markdown-list-face)
+    (markdown-test-range-has-face 85 85 'markdown-list-face)))
 
 (ert-deftest test-markdown-font-lock/definition-list ()
   "A simple definition list marker font lock test."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

CommonMark specification says the too indented line is also treated as list if previous line is list.

#### Before

We cannot check 5th and 6th list.

![before](https://user-images.githubusercontent.com/554281/101794508-4a979980-3b4a-11eb-8629-e225f571df8b.gif)

#### With this patch

![after](https://user-images.githubusercontent.com/554281/101794547-52573e00-3b4a-11eb-9891-69224f1eaa49.gif)


## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#569 (CC: @gabrielmdeal)

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
