### PR TITLE
Support to display local inline images with spaces in file path encoded as %20

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8398,13 +8398,14 @@ or \\[markdown-toggle-inline-images]."
       (widen)
       (goto-char (point-min))
       (while (re-search-forward markdown-regex-link-inline nil t)
-        (let ((start (match-beginning 0))
+        (let* ((start (match-beginning 0))
               (imagep (match-beginning 1))
               (end (match-end 0))
-              (file (match-string-no-properties 6)))
+              (file (match-string-no-properties 6))
+              (unhex_file (url-unhex-string file)))
           (when (and imagep
                      (not (zerop (length file))))
-            (unless (file-exists-p file)
+            (unless (file-exists-p unhex_file)
               (let* ((download-file (funcall markdown-translate-filename-function file))
                      (valid-url (ignore-errors
                                   (member (downcase (url-type (url-generic-parse-url download-file)))
@@ -8414,10 +8415,10 @@ or \\[markdown-toggle-inline-images]."
                   (when (not valid-url)
                     ;; strip query parameter
                     (setq file (replace-regexp-in-string "?.+\\'" "" file))))))
-            (when (file-exists-p file)
-              (let* ((abspath (if (file-name-absolute-p file)
-                                  file
-                                (concat default-directory file)))
+            (when (file-exists-p unhex_file)
+              (let* ((abspath (if (file-name-absolute-p unhex_file)
+                                  unhex_file
+                                (concat default-directory unhex_file)))
                      (image
                       (if (and markdown-max-image-size
                                (image-type-available-p 'imagemagick))


### PR DESCRIPTION
Decode the file path with url-unhex-string before checking and loading the local file so that the images can be displayed.