### PR TITLE
Fix markdown-shifttab for content where is after yaml header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
     -   Fix wrong italic fontification just after code block [GH-548][]
     -   Fix too indended list face issue [GH-569][]
     -   Fix creating imenu index issue when there is no level-1 header too[GH-571][]
+    -   Fix markdown-shifttab for content after yaml header[GH-576][]
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311
@@ -56,6 +57,7 @@
   [gh-560]: https://github.com/jrblevin/markdown-mode/issues/560
   [gh-569]: https://github.com/jrblevin/markdown-mode/issues/569
   [gh-571]: https://github.com/jrblevin/markdown-mode/issues/571
+  [gh-576]: https://github.com/jrblevin/markdown-mode/issues/576
 
 # Markdown Mode 2.4
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -116,7 +116,8 @@ arguments."
   :type '(choice file function (const :tag "None" nil)))
 
 (defcustom markdown-open-image-command nil
-  "Command used for opening image files directly at `markdown-follow-link-at-point'."
+  "Command used for opening image files directly.
+This command is used at `markdown-follow-link-at-point'."
   :group 'markdown
   :type '(choice file function (const :tag "None" nil)))
 
@@ -2140,7 +2141,7 @@ Depending on your font, some reasonable choices are:
 
 (defconst markdown-footnote-chars
   "[[:alnum:]-]"
-  "Regular expression matching any character that is allowed in a footnote identifier.")
+  "Regular expression against a foot note identifier.")
 
 (defconst markdown-regex-footnote-definition
   (concat "^ \\{0,3\\}\\[\\(\\^" markdown-footnote-chars "*?\\)\\]:\\(?:[ \t]+\\|$\\)")
@@ -6700,10 +6701,11 @@ setext header, but should not be folded."
                          (markdown-text-property-at-point
                           'markdown-yaml-metadata-section))))
         (when body
-          (let ((end (progn (goto-char (cl-second body))
-                            (markdown-text-property-at-point
-                             'markdown-yaml-metadata-end))))
-            (outline-flag-region (point-min) (1+ (cl-second end)) nil)))))
+          (let ((end (progn
+                       (goto-char (cl-second body))
+                       (outline-next-visible-heading 1)
+                       (1- (point)))))
+            (outline-flag-region (point-min) end nil)))))
     ;; Hide any false positives in code blocks
     (unless (outline-on-heading-p)
       (outline-next-visible-heading 1))

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -4588,6 +4588,25 @@ date = 2015-08-13 11:35:25 EST
       ;; Check that text is visible
       (markdown-test-range-has-property (point-min) (point-max) 'invisible nil)))))
 
+(ert-deftest test-markdown-outline/visibility-content-after-yaml-header ()
+  "Test not hiding content from YAML header end to first header
+https://github.com/jrblevin/markdown-mode/issues/576."
+  (markdown-test-string
+   "---
+title: \"My Presentation\"
+---
+
+Some preamble goes here.
+
+# My first heading
+
+Here's some text in the first section.
+"
+   (let (last-command this-command)
+     (setq this-command 'markdown-cycle)
+     (markdown-cycle t)
+     (markdown-test-range-has-property 35 59 'invisible nil))))
+
 (ert-deftest test-markdown-outline/level ()
   "Test `markdown-outline-level'."
   (markdown-test-file "outline.text"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

Don't fold content between YAML header end and first header

### Original version

![before](https://user-images.githubusercontent.com/554281/103536781-7b16ed00-4ed6-11eb-91f6-6066090d26c6.gif)

### This patch version

![after](https://user-images.githubusercontent.com/554281/103536796-836f2800-4ed6-11eb-9c8a-39610d64dacd.gif)

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#576 (CC: @plantarum)

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
