### PR TITLE
Feat/inline image size no imagemagick

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
         to automatically define a default link text before prompting the user.
     -   Option to inhibit the prompt for a tooltip text via
         `markdown-disable-tooltip-prompt`.
+    -   Add ability to resize inline image display without Imagemagick in the computer (emulating Org Mode)
 
 *   Improvements:
     -   Correct indirect buffer's indentation in `markdown-edit-code-block` [GH-375][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,6 @@
         to automatically define a default link text before prompting the user.
     -   Option to inhibit the prompt for a tooltip text via
         `markdown-disable-tooltip-prompt`.
-    -   Add ability to resize inline image display without Imagemagick in the computer (emulating Org Mode)
 
 *   Improvements:
     -   Correct indirect buffer's indentation in `markdown-edit-code-block` [GH-375][]
@@ -25,6 +24,7 @@
     -   Enable flyspell check at yaml metadata[GH-560][]
     -   Clean up Makefile
     -   Support to display local image with percent encoding file path
+    -   Add ability to resize inline image display (`markdown-toggle-inline-images`) without Imagemagick installed in the computer (emulating Org Mode)
 
 *   Bug fixes:
     -   Fix remaining flyspell overlay in code block or comment issue [GH-311][]

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8429,13 +8429,17 @@ or \\[markdown-toggle-inline-images]."
                                   unhex_file
                                 (concat default-directory unhex_file)))
                      (image
-                      (if (and markdown-max-image-size
+                      (cond ((and markdown-max-image-size
                                (image-type-available-p 'imagemagick))
-                          (create-image
-                           abspath 'imagemagick nil
-                           :max-width (car markdown-max-image-size)
-                           :max-height (cdr markdown-max-image-size))
-                        (create-image abspath))))
+                             (create-image
+                              abspath 'imagemagick nil
+                              :max-width (car markdown-max-image-size)
+                              :max-height (cdr markdown-max-image-size)))
+                            (markdown-max-image-size
+                             (create-image abspath nil nil
+                                           :max-width (car markdown-max-image-size)
+                                           :max-height (cdr markdown-max-image-size)))
+                            (t (create-image abspath)))))
                 (when image
                   (let ((ov (make-overlay start end)))
                     (overlay-put ov 'display image)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

This is a small enahcnement to `markdown-toggle-inline-images`,
adding a feature to resize the inline display of the image without the need
for Imagemagick present in the computer.

It uses the existing variable `markdown-max-image-size` to
determine the size.

Org Mode now is able to do this (see the code in the link below). This feature
is intended to emulate it in Markdown-mode.

https://github.com/bzg/org-mode/blob/abedf386b3f13af2769728755d00c4698ac5d3b0/lisp/org.el#L16344-L16349

      (create-image file-or-data
		    (and (image-type-available-p 'imagemagick)
			 width
			 'imagemagick)
		    remote?
		    :width width))))


## Related Issue
None

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
