### PR TITLE
WIP: Add support for TOML metadata/frontmatter

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1254,8 +1254,8 @@ giving the bounds of the current and parent list items."
      markdown-gfm-code)
     ;; TODO: This adds recognition of ‘+++’ blocks as TOML metadata,
     ;; but it needs to be cleaned up.
-    (("\\(+\\{3\\}\\)$" markdown-tilde-fence-begin)
-     ("\\(+\\{3\\}\\)$" markdown-tilde-fence-end)
+    (("\\(+\\{3\\}\\)$" markdown-yaml-metadata-begin)
+     ("\\(+\\{3\\}\\)$" markdown-yaml-metadata-end)
      markdown-fenced-code))
   "Mapping of regular expressions to \"fenced-block\" constructs.
 These constructs are distinguished by having a distinctive start


### PR DESCRIPTION
## Description

This adds support to recognize “+++\n...\n+++” blocks as TOML, similar
to “---” YAML metadata. This is a work in progress because the regular
expressions should probably be in `defconst` variables, and we should
use the same method to highlight YAML metadata which I think would then
allow a lot of other code to be deleted. Also, tests would be nice!

## Related Issue

#519 and #137

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

WORK IN PROGRESS: This works, but I haven’t done any of the following (I just got it working on my machine 😅 and wanted to share before going any further):

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
