### PR TITLE
Fix byte-compile warnings for newer Emacs

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -116,7 +116,8 @@ arguments."
   :type '(choice file function (const :tag "None" nil)))
 
 (defcustom markdown-open-image-command nil
-  "Command used for opening image files directly at `markdown-follow-link-at-point'."
+  "Command used for opening image files directly.
+This is used at `markdown-follow-link-at-point'."
   :group 'markdown
   :type '(choice file function (const :tag "None" nil)))
 
@@ -2140,7 +2141,7 @@ Depending on your font, some reasonable choices are:
 
 (defconst markdown-footnote-chars
   "[[:alnum:]-]"
-  "Regular expression matching any character that is allowed in a footnote identifier.")
+  "Regular expression matching any character for a footnote identifier.")
 
 (defconst markdown-regex-footnote-definition
   (concat "^ \\{0,3\\}\\[\\(\\^" markdown-footnote-chars "*?\\)\\]:\\(?:[ \t]+\\|$\\)")


### PR DESCRIPTION
Newer Emacs warns against long docstring lines.

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

Fix following warnings.

```
markdown-mode.el:118:1: Warning: custom-declare-variable
    `markdown-open-image-command' docstring wider than 80 characters
markdown-mode.el:2141:1: Warning: defconst `markdown-footnote-chars' docstring
    wider than 80 characters
```

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
