### PR TITLE
Fix consecutive HTML comments highlighting issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
     -   Fix wrong italic fontification just after code block [GH-548][]
     -   Fix too indended list face issue [GH-569][]
     -   Fix creating imenu index issue when there is no level-1 header too[GH-571][]
+    -   Fix highlighting consecutive HTML comments[GH-584][]
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311
@@ -58,6 +59,7 @@
   [gh-560]: https://github.com/jrblevin/markdown-mode/issues/560
   [gh-569]: https://github.com/jrblevin/markdown-mode/issues/569
   [gh-571]: https://github.com/jrblevin/markdown-mode/issues/571
+  [gh-584]: https://github.com/jrblevin/markdown-mode/issues/584
 
 # Markdown Mode 2.4
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1668,7 +1668,7 @@ region of a YAML metadata block as propertized by
                                     markdown--syntax-properties)
             (put-text-property comment-begin comment-end
                                'markdown-comment (list comment-begin comment-end))
-            (goto-char (min (1+ comment-end) end (point-max)))))
+            (goto-char (min comment-end end (point-max)))))
          ;; Nothing found
          (t (setq finish t)))))
     nil))

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2618,6 +2618,14 @@ Test currently fails because this case isn't handled properly."
    (markdown-test-range-has-face 1 19 'markdown-comment-face)
    (should-not (markdown-range-property-any 1 19 'face '(markdown-inline-code-face)))))
 
+(ert-deftest test-markdown-font-lock/consecutive-html-comments ()
+  "Test for consecutive HTML comments.
+Detail: https://github.com/jrblevin/markdown-mode/issues/584"
+  (markdown-test-string
+   "Main text <!--a comment--><!--another comment-->."
+   (markdown-test-range-has-face 11 26 'markdown-comment-face)
+   (markdown-test-range-has-face 27 28 'markdown-comment-face)))
+
 (ert-deftest test-markdown-font-lock/kbd ()
   "Test font lock for <kbd> tags."
   (markdown-test-string "<kbd>C-c <</kbd>"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

### Original

![before](https://user-images.githubusercontent.com/554281/104329617-72ef2b00-5530-11eb-887a-563068f2d37b.png)

### With this change

![after](https://user-images.githubusercontent.com/554281/104329652-7aaecf80-5530-11eb-84f4-08a4f8afc728.png)

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#584 (CC: @rien333)

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
