### PR TITLE
Extend footnote insertion with text notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
         to automatically define a default link text before prompting the user.
     -   Option to inhibit the prompt for a tooltip text via
         `markdown-disable-tooltip-prompt`.
+    -   Allow insertion of text taged footnotes.
 
 *   Improvements:
     -   Correct indirect buffer's indentation in `markdown-edit-code-block` [GH-375][]
@@ -26,6 +27,7 @@
     -   Support to display local image with percent encoding file path
     -   Add ability to resize inline image display (`markdown-toggle-inline-images`) without Imagemagick installed in the computer (emulating Org Mode)
     -   Support including braces around the language specification in GFM code blocks
+    -   Custom variable to force footnote recount before insertion
 
 *   Bug fixes:
     -   Fix remaining flyspell overlay in code block or comment issue [GH-311][]

--- a/README.md
+++ b/README.md
@@ -830,6 +830,14 @@ provides an interface to all of the possible customizations:
 
   * `markdown-add-footnotes-to-imenu` - Add footnote definitions to
     the end of the imenu index (default: `t`).
+    
+  * `markdown-footnote-default-type` - Wither to insert a number or
+      text tag by default when creating a footnote with
+      `markdown-insert-footnote` (default: `'number`).
+  
+  * `markdown-footnote-always-recalculate-number` - Wither to
+    recalculate the next footnote number when inserting a new number
+    tagged footnote (default: `nil`).
 
   * `comment-auto-fill-only-comments` - variable is made
     buffer-local and set to `nil` by default.  In programming


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Allow insertion of footnotes tagged with text instead of numbers.
<!-- More detailed description of the changes if needed. -->
This behavior is controlled with a variable: `markdown-footnote-default-type`.
Because of the default value set, this is not a breaking change. Changing the customization or
wrapping the function `markdown-insert-footnote` allows this to be useful.

I also introduce a customization to recalculate `markdown-footnote-counter` on each insertion.
I mostly work on small files, and delete footnotes a lot. This makes life easier. Again, by default it 
does not change behavior. 

## Related Issue
None I'm aware of. 
<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
