### PR TITLE
Improve #588

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
         to automatically define a default link text before prompting the user.
     -   Option to inhibit the prompt for a tooltip text via
         `markdown-disable-tooltip-prompt`.
+    -   Introduce `markdown-ordered-list-enumeration` variable [GH-587][]
 
 *   Improvements:
     -   Correct indirect buffer's indentation in `markdown-edit-code-block` [GH-375][]
@@ -60,6 +61,7 @@
   [gh-569]: https://github.com/jrblevin/markdown-mode/issues/569
   [gh-571]: https://github.com/jrblevin/markdown-mode/issues/571
   [gh-584]: https://github.com/jrblevin/markdown-mode/issues/584
+  [gh-587]: https://github.com/jrblevin/markdown-mode/issues/587
 
 # Markdown Mode 2.4
 

--- a/README.md
+++ b/README.md
@@ -905,6 +905,10 @@ provides an interface to all of the possible customizations:
   * `markdown-translate-filename-function` - A function to be used to
     translate filenames in links.
 
+  * `markdown-unordered-list-item-prefix` - When non-nil,
+    `markdown-insert-list-item` inserts enumerated numbers for
+    ordered list marker. While nil, it always inserts `1.`.
+
 Additionally, the faces used for syntax highlighting can be modified to
 your liking by issuing <kbd>M-x customize-group RET markdown-faces</kbd>
 or by using the "Markdown Faces" link at the bottom of the mode

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -427,6 +427,12 @@ The car is used for subscript, the cdr is used for superscripts."
   :group 'markdown
   :type 'string)
 
+(defcustom markdown-ordered-list-disable-enumeration nil
+  "Instead of enumerating ('1. 2. 3. etc.') only use '1. '.
+This will by most viewers renderers be accepted as a numbered list"
+  :group 'markdown
+  :type 'boolean)
+
 (defcustom markdown-nested-imenu-heading-index t
   "Use nested or flat imenu heading index.
 A nested index may provide more natural browsing from the menu,
@@ -6048,7 +6054,7 @@ increase the indentation by one level."
                           (>= (forward-line -1) 0))))
             (let* ((old-prefix (match-string 1))
                    (old-spacing (match-string 2))
-                   (new-prefix (if old-prefix
+                   (new-prefix (if (and old-prefix (not markdown-ordered-list-disable-enumeration))
                                    (int-to-string (1+ (string-to-number old-prefix)))
                                  "1"))
                    (space-adjust (- (length old-prefix) (length new-prefix)))
@@ -6172,8 +6178,11 @@ a list."
          ((or (= (length cpfx) (length pfx))
               (= (length cur-item) (length prev-item)))
           (save-excursion
+            (setq idx (1+ idx))
             (replace-match
-             (concat pfx (number-to-string (setq idx (1+ idx))) ". ")))
+             (if markdown-ordered-list-disable-enumeration
+                 (concat pfx "1. ")
+                 (concat pfx (number-to-string idx) ". "))))
           (setq sep nil))
          ;; indented a level
          ((< (length pfx) (length cpfx))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -427,11 +427,12 @@ The car is used for subscript, the cdr is used for superscripts."
   :group 'markdown
   :type 'string)
 
-(defcustom markdown-ordered-list-disable-enumeration nil
-  "Instead of enumerating ('1. 2. 3. etc.') only use '1. '.
-This will by most viewers renderers be accepted as a numbered list"
+(defcustom markdown-ordered-list-enumeration t
+  "When non-nil, use enumerated numbers(1. 2. 3. etc.) for ordered list marker.
+While nil, always uses '1.' for the marker"
   :group 'markdown
-  :type 'boolean)
+  :type 'boolean
+  :package-version '(markdown-mode . "2.5"))
 
 (defcustom markdown-nested-imenu-heading-index t
   "Use nested or flat imenu heading index.
@@ -6054,7 +6055,7 @@ increase the indentation by one level."
                           (>= (forward-line -1) 0))))
             (let* ((old-prefix (match-string 1))
                    (old-spacing (match-string 2))
-                   (new-prefix (if (and old-prefix (not markdown-ordered-list-disable-enumeration))
+                   (new-prefix (if (and old-prefix markdown-ordered-list-enumeration)
                                    (int-to-string (1+ (string-to-number old-prefix)))
                                  "1"))
                    (space-adjust (- (length old-prefix) (length new-prefix)))
@@ -6178,11 +6179,11 @@ a list."
          ((or (= (length cpfx) (length pfx))
               (= (length cur-item) (length prev-item)))
           (save-excursion
-            (setq idx (1+ idx))
             (replace-match
-             (if markdown-ordered-list-disable-enumeration
+             (if (not markdown-ordered-list-enumeration)
                  (concat pfx "1. ")
-                 (concat pfx (number-to-string idx) ". "))))
+               (cl-incf idx)
+               (concat pfx (number-to-string idx) ". "))))
           (setq sep nil))
          ;; indented a level
          ((< (length pfx) (length cpfx))

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -1157,6 +1157,25 @@ Don't adjust spacing if tabs are used as whitespace."
             (buffer-string)
             "1. A\n    * AA\n        1. AAA\n    * \n2. \n3. "))))
 
+(ert-deftest test-markdown-insertion/with-markdown-ordered-list-enumeration ()
+  "Test for `markdown-ordered-list-enumeration'.
+Detail: https://github.com/jrblevin/markdown-mode/issues"
+  (markdown-test-string "1. A"
+    (goto-char (point-max))
+    (let ((markdown-ordered-list-enumeration t))
+      (call-interactively 'markdown-insert-list-item)
+      (let ((line (buffer-substring-no-properties
+                   (line-beginning-position) (line-end-position))))
+        (should (string= line "2. "))))
+
+    (markdown-test-string "1. A"
+      (goto-char (point-max))
+      (let ((markdown-ordered-list-enumeration nil))
+        (call-interactively 'markdown-insert-list-item)
+        (let ((line (buffer-substring-no-properties
+                     (line-beginning-position) (line-end-position))))
+          (should (string= line "1. ")))))))
+
 (ert-deftest test-markdown-insertion/reference-link ()
   "Basic tests for `markdown-insert-reference-link'."
   ;; Test optional parameters (leave point after link)


### PR DESCRIPTION
## Description

Changes from #588 

- rename variable name from `markdown-ordered-list-disable-enumeration` to `markdown-ordered-list-enumeration`. Because I suppose we should avoid using double negative(`disable` and its default value is `nil`)
- Add unit test
- Update document

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#587, #588

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x ] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
