### PR TITLE
Fix: make C-c C-o recursively locate a .md file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@
     -   Fix too indended list face issue [GH-569][]
     -   Fix creating imenu index issue when there is no level-1 header too[GH-571][]
     -   Fix highlighting consecutive HTML comments[GH-584][]
+    -   Fix `markdown-follow-thing-at-point` failing on subdir search [GH-590][]
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311
@@ -62,6 +63,7 @@
   [gh-571]: https://github.com/jrblevin/markdown-mode/issues/571
   [gh-584]: https://github.com/jrblevin/markdown-mode/issues/584
   [gh-587]: https://github.com/jrblevin/markdown-mode/issues/587
+  [gh-590]: https://github.com/jrblevin/markdown-mode/issues/590
 
 # Markdown Mode 2.4
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7811,7 +7811,7 @@ link name must be available via `match-string'."
            (not (markdown-code-block-at-point-p))
            (or (not buffer-file-name)
                (not (string-equal (buffer-file-name)
-                                  (save-match-data 
+                                  (save-match-data
                                    (markdown-convert-wiki-link-to-filename
                                     (markdown-wiki-link-link))))))))))
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7811,8 +7811,9 @@ link name must be available via `match-string'."
            (not (markdown-code-block-at-point-p))
            (or (not buffer-file-name)
                (not (string-equal (buffer-file-name)
-                                  (markdown-convert-wiki-link-to-filename
-                                   (markdown-wiki-link-link)))))))))
+                                  (save-match-data 
+                                   (markdown-convert-wiki-link-to-filename
+                                    (markdown-wiki-link-link))))))))))
 
 (defun markdown-wiki-link-link ()
   "Return the link part of the wiki link using current match data.


### PR DESCRIPTION
When configuring wiki-links to *allow* whitespace in filenames, there is a bug in C-c C-o not really locating files recursively.

## Description

When using:

```elisp
(use-package markdown-mode
  :config
  (setq markdown-enable-wiki-links t)
  (setq markdown-wiki-link-search-subdirectories t)
  (setq markdown-link-space-sub-char " "))
```

<kbd>C-c C-o</kbd> will bail out if the target exists in sub-directories. 

```
Debugger entered--Lisp error: (wrong-type-argument arrayp nil)
  substring(nil 0 0)
  replace-regexp-in-string("[[:space:]\n]" " " nil)
  markdown-convert-wiki-link-to-filename(nil)
  markdown-follow-wiki-link(nil nil)
  markdown-follow-wiki-link-at-point(nil)
  markdown-follow-thing-at-point(nil)
  funcall-interactively(markdown-follow-thing-at-point nil)
  call-interactively(markdown-follow-thing-at-point nil nil)
  command-execute(markdown-follow-thing-at-point)
```

Using `save-match-data` fixes that.

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).
