### PR TITLE
Fix markdown-wiki-link-p overriding match data issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@
     -   Fix too indended list face issue [GH-569][]
     -   Fix creating imenu index issue when there is no level-1 header too[GH-571][]
     -   Fix highlighting consecutive HTML comments[GH-584][]
+    -   Fix `markdown-follow-thing-at-point` failing on subdir search [GH-590][]
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311
@@ -62,6 +63,7 @@
   [gh-571]: https://github.com/jrblevin/markdown-mode/issues/571
   [gh-584]: https://github.com/jrblevin/markdown-mode/issues/584
   [gh-587]: https://github.com/jrblevin/markdown-mode/issues/587
+  [gh-590]: https://github.com/jrblevin/markdown-mode/pull/590
 
 # Markdown Mode 2.4
 

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -6352,6 +6352,23 @@ x|"
             (markdown-test-range-has-property 19 26 'font-lock-face 'markdown-link-face))
         (kill-buffer)))))
 
+(ert-deftest test-markdown-ext/wiki-link-keep-match-data ()
+  "Test that markdown-wiki-link-p keeps expected match data.
+Detail: https://github.com/jrblevin/markdown-mode/pull/590"
+  (let ((markdown-enable-wiki-links t)
+        (markdown-link-space-sub-char " ")
+        (markdown-wiki-link-search-subdirectories t))
+    (progn
+      (find-file "wiki/pr590/Guide.md")
+      (unwind-protect
+          (progn
+            (markdown-mode)
+            (re-search-forward "Zettel Markdown")
+            (goto-char (match-beginning 0))
+            (should (markdown-wiki-link-p))
+            (should (string= (markdown-wiki-link-link) "Zettel Markdown")))
+        (kill-buffer)))))
+
 (ert-deftest test-markdown-ext/wiki-link-major-mode ()
   "Test major-mode of linked page."
   (let ((markdown-enable-wiki-links t)

--- a/tests/wiki/pr590/Guide.md
+++ b/tests/wiki/pr590/Guide.md
@@ -1,0 +1,1 @@
+**Basics**: A neuron notebook is just a directory of [[Zettel Markdown]] files

--- a/tests/wiki/pr590/Guide/Zettel Markdown.md
+++ b/tests/wiki/pr590/Guide/Zettel Markdown.md
@@ -1,0 +1,2 @@
+Zettel files are written in Markdown
+

--- a/tests/wiki/pr590/Guide/Zettel Markdown/math.md
+++ b/tests/wiki/pr590/Guide/Zettel Markdown/math.md
@@ -1,0 +1,1 @@
+# Math support


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

This is improved version of #590.

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#590. CC: @srid

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
