### PR TITLE
Silence byte-compiler

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7865,7 +7865,11 @@ The location of the alias component depends on the value of
                return it)
       (progn
         (require 'project)
-        (car (project-roots (project-current t))))))
+        (let ((project (project-current t)))
+          (with-no-warnings
+            (if (fboundp 'project-root)
+                (project-root project)
+              (car (project-roots project))))))))
 
 (defun markdown-convert-wiki-link-to-filename (name)
   "Generate a filename from the wiki link NAME.


### PR DESCRIPTION
Starting with project v0.3.0 `project-roots` is obsolete and `project-root` should be used instead.

## Description

We change it so that `project-root` is used if available, else `project-roots`. Wrap a `with-no-warnings` around it to silence both new and old byte-compilers.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] *not necessary* I have updated the documentation in the **README.md** file if necessary.
- [ ] *that would be silly* I have added an entry to **CHANGES.md**.
- [ ] *that would be silly* I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).