### PR TITLE
Add markdown-insert-gfm-foldable-block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
         `markdown-disable-tooltip-prompt`.
     -   Introduce `markdown-ordered-list-enumeration` variable [GH-587][]
     -   Search wiki link under project
+    -   Add `markdown-insert-gfm-foldable-block` function [GH-596][]
 
 *   Improvements:
     -   Correct indirect buffer's indentation in `markdown-edit-code-block` [GH-375][]
@@ -65,6 +66,7 @@
   [gh-584]: https://github.com/jrblevin/markdown-mode/issues/584
   [gh-587]: https://github.com/jrblevin/markdown-mode/issues/587
   [gh-590]: https://github.com/jrblevin/markdown-mode/pull/590
+  [gh-596]: https://github.com/jrblevin/markdown-mode/pull/596
 
 # Markdown Mode 2.4
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4332,6 +4332,56 @@ opening code fence and an info string."
   :group 'markdown
   :type 'boolean)
 
+(defun markdown-insert-gfm-foldable-block ()
+  "Insert details disclosure element which creates a disclosure
+  widget that can be used for having foldable content. More
+  detais here 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details'"
+  (interactive
+   (let ((details-open-tag "<details>")
+         (details-close-tag "</details>")
+         (summary-open-tag "<summary>")
+         (summary-close-tag " </summary>"))
+     (if (use-region-p)
+         (let* ((b (region-beginning)) (e (region-end)) end
+                (indent (progn (goto-char b) (current-indentation))))
+           (goto-char e)
+           ;; if we're on a blank line, don't newline, otherwise the tags
+           ;; should go on its own line
+           (unless (looking-back "\n" nil)
+             (newline))
+           (indent-to indent)
+           (insert details-close-tag)
+           (markdown-ensure-blank-line-after)
+           (setq end (point))
+           (goto-char b)
+           ;; if we're on a blank line, insert the quotes here, otherwise
+           ;; add a new line first
+           (unless (looking-at-p "\n")
+             (newline)
+             (forward-line -1))
+           (markdown-ensure-blank-line-before)
+           (indent-to indent)
+           (insert details-open-tag "\n")
+           (insert summary-open-tag summary-close-tag)
+           (search-backward summary-close-tag)
+           (markdown-syntax-propertize-fenced-block-constructs (point-at-bol) end))
+       (let ((indent (current-indentation))
+             start-bol)
+         (delete-horizontal-space :backward-only)
+         (markdown-ensure-blank-line-before)
+         (indent-to indent)
+         (setq start-bol (point-at-bol))
+         (insert details-open-tag "\n")
+         (insert summary-open-tag summary-close-tag "\n")
+         (insert details-close-tag "\n")
+         (indent-to indent)
+         (markdown-ensure-blank-line-after)
+         (markdown-syntax-propertize-fenced-block-constructs start-bol (point))
+         (search-backward summary-close-tag))
+       )
+     )
+   ))
+
 (defun markdown-insert-gfm-code-block (&optional lang edit)
   "Insert GFM code block for language LANG.
 If LANG is nil, the language will be queried from user.  If a

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4333,9 +4333,9 @@ opening code fence and an info string."
   :type 'boolean)
 
 (defun markdown-insert-gfm-foldable-block ()
-  "Insert details disclosure element which creates a disclosure
-  widget that can be used for having foldable content. More
-  detais here 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details'"
+  "Insert details disclosure element to make content foldable.
+If a region is active, wrap this region with the disclosure
+element. More detais here 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details'."
   (interactive
    (let ((details-open-tag "<details>")
          (details-close-tag "</details>")


### PR DESCRIPTION
This can be used for adding a collapsible content. Works in both
github and gitlab from my testing.

More details here: https://github.com/jrblevin/markdown-mode/issues/595


## Description

Both github and gitlab support the feature where you can use to  fold a content: https://stackoverflow.com/questions/52214187/how-can-i-fold-content-in-github-markdown

## Related Issue

https://github.com/jrblevin/markdown-mode/issues/595

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
