### PR TITLE
Fix `markdown-table-backward-cell' so it always goes back a single cell

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@
     -   Fix creating imenu index issue when there is no level-1 header too[GH-571][]
     -   Fix highlighting consecutive HTML comments[GH-584][]
     -   Fix `markdown-follow-thing-at-point` failing on subdir search [GH-590][]
+    -   Fix `markdown-table-backward-cell' so it always goes back a single cell
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9247,15 +9247,23 @@ Create new table lines if required."
   (unless (markdown-table-at-point-p)
     (user-error "Not at a table"))
   (markdown-table-align)
-  (when (markdown-table-hline-at-point-p) (end-of-line 1))
+  (when (markdown-table-hline-at-point-p) (beginning-of-line 1))
   (condition-case nil
       (progn
         (re-search-backward "\\(?:^\\|[^\\]\\)|" (markdown-table-begin))
+        ;; When this function is called while in the first cell in a
+        ;; table, the point will now be at the beginning of a line. In
+        ;; this case, we need to move past one additional table
+        ;; boundary, the end of the table on the previous line.
+        (when (= (point) (line-beginning-position))
+          (re-search-backward "\\(?:^\\|[^\\]\\)|" (markdown-table-begin)))
         (re-search-backward "\\(?:^\\|[^\\]\\)|" (markdown-table-begin)))
     (error (user-error "Cannot move to previous table cell")))
-  (while (looking-at "|\\([-:]\\|[ \t]*$\\)")
-    (re-search-backward "\\(?:^\\|[^\\]\\)|" (markdown-table-begin)))
-  (when (looking-at "| ?") (goto-char (match-end 0))))
+  (when (looking-at "\\(?:^\\|[^\\]\\)| ?") (goto-char (match-end 0)))
+
+  ;; This may have dropped point on the hline.
+  (when (markdown-table-hline-at-point-p)
+    (markdown-table-backward-cell)))
 
 (defun markdown-table-transpose ()
   "Transpose table at point.

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -6799,6 +6799,53 @@ title: asdasdasd
     (search-forward "title: ")
     (should (markdown-test-flyspell-incorrect-word-p))))
 
+(ert-deftest test-markdown-table/navigation-forward-cell ()
+  "Test table navigation."
+  (markdown-test-string "
+| 1  | 2  | 3  | 4  |
+|----|----|----|----|
+| 5  | 6  | 7  | 8  |
+| 9  | 10 | 11 | 12 |"
+    (search-forward "1 ")
+    (let ((index 2))
+      (while (<= index 12)
+        (markdown-table-forward-cell)
+        (should (looking-at (format "%d" index)))
+        (cl-incf index)))))
+
+(ert-deftest test-markdown-table/navigation-backward-cell ()
+  "Test table navigation."
+  (markdown-test-string "
+| 1  | 2  | 3  | 4  |
+|----|----|----|----|
+| 5  | 6  | 7  | 8  |
+| 9  | 10 | 11 | 12 |
+"
+    (search-forward "12")
+    (let ((index 11))
+      (while (>= index 1)
+        (markdown-table-backward-cell)
+        (should (looking-at (format "%d" index)))
+        (cl-decf index)))))
+
+(ert-deftest test-markdown-table/align ()
+  "Test table realignment."
+  (markdown-test-string "
+| Header 1 |Header 2|
+|------|----|
+| | |
+| A very very very long cell| |
+"
+    (search-forward "Header")
+    (markdown-table-align)
+    (message "\"%s\"" (buffer-string))
+    (should (string= (buffer-string) "
+| Header 1                   | Header 2 |
+|----------------------------|----------|
+|                            |          |
+| A very very very long cell |          |
+"))))
+
 (provide 'markdown-test)
 
 ;;; markdown-test.el ends here


### PR DESCRIPTION
## Description

Simple fix for table navigation. Also adds unit tests.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).
  - I don't have `ispell` installed, so those tests are failing locally. All other tests pass.