### PR TITLE
markdown-mode.el: add the "markdown_py" into default initialize-list for "markdown-command"

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -92,7 +92,7 @@ Any changes to the output buffer made by this hook will be saved.")
   :group 'text
   :link '(url-link "https://jblevins.org/projects/markdown-mode/"))
 
-(defcustom markdown-command (let ((command (cl-loop for cmd in '("markdown" "pandoc")
+(defcustom markdown-command (let ((command (cl-loop for cmd in '("markdown" "pandoc" "markdown_py")
                                                     when (executable-find cmd)
                                                     return (file-name-nondirectory it))))
                               (or command "markdown"))


### PR DESCRIPTION
`markdown_py` is another popular markdown CLI, add it into default initialize-list for "markdown-command" should be convenient for many users.

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
* No section for default initilize-list for `markdown-command`
- [ ] I have added an entry to **CHANGES.md**.
* No section for default initilize-list for `markdown-command`
- [ ] I have added tests to cover my changes.
* No test case for initialize-list for `markdown-command`
- [x] All new and existing tests passed (using `make test`).
