### PR TITLE
Fix broken inline display of remote images

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8539,7 +8539,7 @@ or \\[markdown-toggle-inline-images]."
                     ;; strip query parameter
                     (setq file (replace-regexp-in-string "?.+\\'" "" file))
                     (unless (file-exists-p file)
-                      (setq file (file (url-unhex-string file))))))))
+                      (setq file (url-unhex-string file)))))))
             (when (file-exists-p file)
               (let* ((abspath (if (file-name-absolute-p file)
                                   file

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8525,11 +8525,10 @@ or \\[markdown-toggle-inline-images]."
         (let* ((start (match-beginning 0))
               (imagep (match-beginning 1))
               (end (match-end 0))
-              (file (match-string-no-properties 6))
-              (unhex_file (url-unhex-string file)))
+              (file (match-string-no-properties 6)))
           (when (and imagep
                      (not (zerop (length file))))
-            (unless (file-exists-p unhex_file)
+            (unless (file-exists-p file)
               (let* ((download-file (funcall markdown-translate-filename-function file))
                      (valid-url (ignore-errors
                                   (member (downcase (url-type (url-generic-parse-url download-file)))
@@ -8538,11 +8537,13 @@ or \\[markdown-toggle-inline-images]."
                     (setq file (markdown--get-remote-image download-file))
                   (when (not valid-url)
                     ;; strip query parameter
-                    (setq file (replace-regexp-in-string "?.+\\'" "" file))))))
-            (when (file-exists-p unhex_file)
-              (let* ((abspath (if (file-name-absolute-p unhex_file)
-                                  unhex_file
-                                (concat default-directory unhex_file)))
+                    (setq file (replace-regexp-in-string "?.+\\'" "" file))
+                    (unless (file-exists-p file)
+                      (setq file (file (url-unhex-string file))))))))
+            (when (file-exists-p file)
+              (let* ((abspath (if (file-name-absolute-p file)
+                                  file
+                                (concat default-directory file)))
                      (image
                       (cond ((and markdown-max-image-size
                                (image-type-available-p 'imagemagick))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->
#575 introduced a regression which prevents displaying the downloaded images (only `unhex_file` is checked, while the image is stored in `file`).

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)