### PR TITLE
Make markdown-mouse-follow-link work when nil

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -617,7 +617,7 @@ requires Emacs to be built with ImageMagick support."
   "Non-nil means mouse on a link will follow the link.
 This variable must be set before loading markdown-mode."
   :group 'markdown
-  :type 'bool
+  :type 'boolean
   :safe 'booleanp
   :package-version '(markdown-mode . "2.5"))
 
@@ -5396,11 +5396,11 @@ Assumes match data is available for `markdown-regex-italic'."
   "Keymap for Markdown major mode.")
 
 (defvar markdown-mode-mouse-map
-  (when markdown-mouse-follow-link
-    (let ((map (make-sparse-keymap)))
+  (let ((map (make-sparse-keymap)))
+    (when markdown-mouse-follow-link
       (define-key map [follow-link] 'mouse-face)
-      (define-key map [mouse-2] #'markdown-follow-thing-at-point)
-      map))
+      (define-key map [mouse-2] #'markdown-follow-thing-at-point))
+      map)
   "Keymap for following links with mouse.")
 
 (defvar gfm-mode-map
@@ -7730,6 +7730,7 @@ Translate filenames using `markdown-filename-translate-function'."
 
 (defun markdown-fontify-inline-links (last)
   "Add text properties to next inline link from point to LAST."
+  (when markdown-mouse-follow-link
   (when (markdown-match-generic-links last nil)
     (let* ((link-start (match-beginning 3))
            (link-end (match-end 3))
@@ -7773,7 +7774,7 @@ Translate filenames using `markdown-filename-translate-function'."
       (when title-start (add-text-properties url-end title-end tp))
       (when (and markdown-hide-urls url-start)
         (compose-region url-start (or title-end url-end) url-char))
-      t)))
+      t))))
 
 (defun markdown-fontify-reference-links (last)
   "Add text properties to next reference link from point to LAST."


### PR DESCRIPTION
Hi,
This PR makes markdown-mode behave as intended when markdown-mouse-follow-link (introduced in commit 0fdbf89fc825dc2675d0d78469d235a39c32a183) is false: no link highlighting through mouse-face, and no link following.  No guarantee as to the cleanliness or elegance of the hack, but an improvement over the preceding state. Also corrects a minor bug which prevented the variable from being customisable interactively.

In summary this commit
1. corrects the variable type so it can be toggled in customize-mode
2. defines markdown-mode-mouse-map to an empty map instead of just breaking it
3. deactivates the mouse-face property attribution when no link
   following wanted.
This provides the (presumably) intended behaviour when set to nil.

Thanks for markdown-mode! 
cheers, Adrian

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).
