### PR TITLE
Fix delimiter regex in markdown-table-align

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@
     -   Fix highlighting consecutive HTML comments[GH-584][]
     -   Fix `markdown-follow-thing-at-point` failing on subdir search [GH-590][]
     -   Fix `markdown-table-backward-cell' so it always goes back a single cell
+    -   Fix 'markdown-table-align' to detect delimiters surrounded by spaces
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9087,7 +9087,7 @@ This function assumes point is on a table."
             (indent (progn (looking-at "[ \t]*") (match-string 0)))
             ;; Split table in lines and save column format specifier
             (lines (mapcar (lambda (l)
-                             (if (string-match-p "\\`[ \t]*|[-:]" l)
+                             (if (string-match-p "\\`[ \t]*| *[-:]" l)
                                  (progn (setq fmtspec (or fmtspec l)) nil) l))
                            (markdown--split-string (buffer-substring begin end) "\n")))
             ;; Split lines in cells

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9087,7 +9087,7 @@ This function assumes point is on a table."
             (indent (progn (looking-at "[ \t]*") (match-string 0)))
             ;; Split table in lines and save column format specifier
             (lines (mapcar (lambda (l)
-                             (if (string-match-p "\\`[ \t]*| *[-:]" l)
+                             (if (string-match-p "\\`[ \t]*|[ \t]*[-:]" l)
                                  (progn (setq fmtspec (or fmtspec l)) nil) l))
                            (markdown--split-string (buffer-substring begin end) "\n")))
             ;; Split lines in cells

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -6903,6 +6903,21 @@ title: asdasdasd
 | A very very very long cell |          |
 "))))
 
+(ert-deftest test-markdown-table/align-with-spaces-before-delimiter ()
+  "Test table realignment when there are spaces before a delimiter"
+  (markdown-test-string "
+| A | B | C | D |
+| - | :- | :-: | -: |
+| aaa | bbbb | ccccc | dddddd |
+"
+    (search-forward "A")
+    (markdown-table-align)
+    (should (string= (buffer-string) "
+| A   | B    | C     |      D |
+|-----|:-----|:-----:|-------:|
+| aaa | bbbb | ccccc | dddddd |
+"))))
+
 (provide 'markdown-test)
 
 ;;; markdown-test.el ends here

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5921,7 +5921,7 @@ Details: https://github.com/jrblevin/markdown-mode/issues/308"
     (markdown-table-align)
     (should (string= (buffer-substring-no-properties (point-min) (point-max))
                      "| Col1 | Col2 |
-| :-:  | :-:  |
+|:----:|:----:|
 | AAA  | A\\|B |\n"))))
 
 (ert-deftest test-markdown-table/align-with-wiki-link ()

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -6918,6 +6918,21 @@ title: asdasdasd
 | aaa | bbbb | ccccc | dddddd |
 "))))
 
+(ert-deftest test-markdown-table/align-with-tabs-before-delimiter ()
+  "Test table realignment when there are tabs before a delimiter"
+  (markdown-test-string "
+| A | B | C | D |
+|	-	|	:-|:-:	|-:|
+| aaa | bbbb | ccccc | dddddd |
+"
+    (search-forward "A")
+    (markdown-table-align)
+    (should (string= (buffer-string) "
+| A   | B    | C     |      D |
+|-----|:-----|:-----:|-------:|
+| aaa | bbbb | ccccc | dddddd |
+"))))
+
 (provide 'markdown-test)
 
 ;;; markdown-test.el ends here


### PR DESCRIPTION
The regex in markdown-table-align to detect a delimiter row doesn't work when table delimiters are surrounded by spaces. This pull request fixes that issue and the expexted value of an existing test.

## Description

Consider the following table:
```md
| A |
| - |
|abcabcabcabc|
```

The original regex can not detect the delimiter row because the hyphen is surrounded by spaces.

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] I have updated an existing test.
- [x] All new and existing tests passed (using `make test`).
