### PR TITLE
Fix #578 flatten circular list in nested imenu index

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
     -   Improve `markdown-insert-{bold,italic}` when region starts with spaces[GH-613][]
 
 *   Bug fixes:
+    -   Fix issue with `nil` being returned from `markdown-imenu-create-nested-index` [GH-578][]
     -   Fix remaining flyspell overlay in code block or comment issue [GH-311][]
     -   Fix inline URL regular expression which starts/ends with spaces [GH-514][]
     -   Fix GFM italic fontification for one character [GH-524][]

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5682,6 +5682,7 @@ See `imenu-create-index-function' and `imenu--index-alist' for details."
                      (setcdr sibling-alist alist)
                      (setq cur-alist alist))
                    (setq cur-level level)))))
+      (setq root (copy-tree root))
       ;; Footnotes
       (let ((fn (markdown-get-defined-footnotes)))
         (if (or (zerop (length fn))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

These [two lines](https://github.com/jrblevin/markdown-mode/blob/master/markdown-mode.el#L5666-L5667) have created a circular list, and the new nativecomp JIT can't handle them.

<!-- More detailed description of the changes if needed. -->

## Related Issue

#578
<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
