### PR TITLE
Fix broken :type for two custom values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@
     -   Fix `markdown-follow-thing-at-point` failing on subdir search [GH-590][]
     -   Fix `markdown-table-backward-cell' so it always goes back a single cell
     -   Fix 'markdown-table-align' to detect delimiters surrounded by spaces
+    -   Fix customization for `markdown-mouse-follow-link` and `markdown-table-align-p`
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -617,14 +617,14 @@ requires Emacs to be built with ImageMagick support."
   "Non-nil means mouse on a link will follow the link.
 This variable must be set before loading markdown-mode."
   :group 'markdown
-  :type 'bool
+  :type 'boolean
   :safe 'booleanp
   :package-version '(markdown-mode . "2.5"))
 
 (defcustom markdown-table-align-p t
   "Non-nil means that table is aligned after table operation."
   :group 'markdown
-  :type 'bool
+  :type 'boolean
   :safe 'booleanp
   :package-version '(markdown-mode . "2.5"))
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

For two values the type is specified as `'bool` instead of `'boolean`, breaking customization UI.

To reproduce: look up `markdown-table-align-p` in the customization UI, watch it break, observe this in `*Messages*`:

```
widget-apply: Symbol’s function definition is void: nil
```

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
