### PR TITLE
Sh shell

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@
         name for `C-m`.
     -   Give `markdown-table-at-point-p-function` a non-nil default.
         Simplify `markdown-table-at-point-p` accordingly.
+    -   Auto set `sh-shell` when `markdown-edit-code-block` enter indirect buffer with `sh-mode`
 
 *   Bug fixes:
     -   Fix issue with `nil` being returned from `markdown-imenu-create-nested-index` [GH-578][]

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -47,8 +47,10 @@
 (defvar jit-lock-end)
 (defvar flyspell-generic-check-word-predicate)
 (defvar electric-pair-pairs)
+(defvar sh-ancestor-alist)
 
 (declare-function project-roots "project")
+(declare-function sh-set-shell "sh-script")
 
 
 ;;; Constants =================================================================
@@ -8784,6 +8786,15 @@ at the END of code blocks."
                       (lambda (_parent-buffer _beg _end)
                         (funcall mode)))
                      (indirect-buf (edit-indirect-region begin end 'display-buffer)))
+                  ;; reset `sh-shell' when indirect buffer
+                (when (and (not (member system-type '(ms-dos windows-nt)))
+                           (member mode '(shell-script-mode sh-mode))
+                           (member lang (append
+                                         (mapcar (lambda (e) (symbol-name (car e)))
+                                                 sh-ancestor-alist)
+                                         '("csh" "rc" "sh"))))
+                  (with-current-buffer indirect-buf
+                    (sh-set-shell lang)))
                 (when (> indentation 0) ;; un-indent in edit-indirect buffer
                   (with-current-buffer indirect-buf
                     (indent-rigidly (point-min) (point-max) (- indentation)))))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

When edit a code block with `sh-mode `(`bash`,`sh`,`zsh`,`ksh`,etc) in indirect buffer, the `sh-mode` always set default value of  `sh-shell` rather than according to `(markdown-code-block-lang)`

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
