### PR TITLE
Fix table operations with escaped vertical bar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,7 @@
         `syntax-propertize-extend-region-functions`.
     -   Fix list highlighting issue in code block [GH-631][]
     -   Fix exception when inserting code block at end of buffer [GH-634][]
+    -   Fix table operations when table column contains escaped vertical bars [GH-635][]
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311
@@ -99,6 +100,7 @@
   [gh-625]: https://github.com/jrblevin/markdown-mode/issues/625
   [gh-631]: https://github.com/jrblevin/markdown-mode/issues/631
   [gh-634]: https://github.com/jrblevin/markdown-mode/issues/634
+  [gh-635]: https://github.com/jrblevin/markdown-mode/issues/635
 
 # Markdown Mode 2.4
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9000,7 +9000,8 @@ This function assumes point is on a table."
     (save-excursion
       (beginning-of-line)
       (while (search-forward "|" pos t)
-        (unless (markdown--thing-at-wiki-link (match-beginning 0))
+        (when (and (not (looking-back "\\\\|" (line-beginning-position)))
+                   (not (markdown--thing-at-wiki-link (match-beginning 0))))
           (setq cnt (1+ cnt)))))
     cnt))
 
@@ -9039,7 +9040,8 @@ table."
   (beginning-of-line 1)
   (when (> n 0)
     (while (and (> n 0) (search-forward "|" (point-at-eol) t))
-      (unless (markdown--thing-at-wiki-link (match-beginning 0))
+      (when (and (not (looking-back "\\\\|" (line-beginning-position)))
+                 (not (markdown--thing-at-wiki-link (match-beginning 0))))
         (cl-decf n)))
     (if on-delim
         (backward-char 1)
@@ -9257,7 +9259,7 @@ With optional argument UP, move it up."
      (goto-char begin)
      (while (< (point) end)
        (markdown-table-goto-column col t)
-       (and (looking-at "|[^|\n]+|")
+       (and (looking-at "|\\(?:\\\\|\\|[^|\n]\\)+|")
             (replace-match "|"))
        (forward-line)))
     (set-marker end nil)
@@ -9284,7 +9286,7 @@ With optional argument LEFT, move it to the left."
      (goto-char begin)
      (while (< (point) end)
        (markdown-table-goto-column col1 t)
-       (when (looking-at "|\\([^|\n]+\\)|\\([^|\n]+\\)|")
+       (when (looking-at "|\\(\\(?:\\\\|\\|[^|\n]\\|\\)+\\)|\\(\\(?:\\\\|\\|[^|\n]\\|\\)+\\)|")
          (replace-match "|\\2|\\1|"))
        (forward-line)))
     (set-marker end nil)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -6003,6 +6003,17 @@ Details: https://github.com/jrblevin/markdown-mode/issues/308"
       (markdown-table-goto-column 2)
       (should (string= (thing-at-point 'word) "Content")))))
 
+(ert-deftest test-markdown-table/get-column-with-escaped-vertical-bar ()
+  "Test for getting column number with escaped vertical bar.
+Details: https://github.com/jrblevin/markdown-mode/issues/635"
+  (markdown-test-string "| Col1 | Col2 \\| Col2 \\| Col2 |"
+    (search-forward "Col2")
+    (should (= (markdown-table-get-column) 2))
+    (search-forward "Col2")
+    (should (= (markdown-table-get-column) 2))
+    (search-forward "Col2")
+    (should (= (markdown-table-get-column) 2))))
+
 (ert-deftest test-markdown-table/transpose-with-wiki-link ()
   "Test for table transpose with link.
 Detail: https://github.com/jrblevin/markdown-mode/commit/44a1c5bbc5d9514e97c7cc0a90a0c578130cd1dc"
@@ -6052,6 +6063,44 @@ Detail: https://github.com/jrblevin/markdown-mode/issues/522"
     (backward-char 1)
     (markdown-table-backward-cell)
     (should (char-equal (char-after) ?x))))
+
+(ert-deftest test-markdown-table/column-move-with-escaped-vertical-bar ()
+  "Test for column move with escaped vertical bar.
+Details: https://github.com/jrblevin/markdown-mode/issues/635"
+  (markdown-test-string "| a \\| | b |"
+    (search-forward "b")
+    (markdown-table-move-column-left)
+    (should (string= (buffer-substring-no-properties (line-beginning-position) (line-end-position))
+                     "| b | a \\| |")))
+
+  (markdown-test-string "| a \\| | b |"
+    (search-forward "a")
+    (markdown-table-move-column-right)
+    (should (string= (buffer-substring-no-properties (line-beginning-position) (line-end-position))
+                     "| b | a \\| |"))))
+
+(ert-deftest test-markdown-table/insert-column-with-escaped-vertical-bar ()
+  "Test for inserting column with escaped vertical bar.
+Details: https://github.com/jrblevin/markdown-mode/issues/635"
+  (markdown-test-string "| a | b \\| bb |
+| c | d |"
+    (search-forward "bb")
+    (markdown-table-insert-column)
+    (should (string= (buffer-string)
+                     "| a |   | b \\| bb |
+| c |   | d       |
+"))))
+
+(ert-deftest test-markdown-table/delete-column-with-escaped-vertical-bar ()
+  "Test for deleting column with escaped vertical bar.
+Details: https://github.com/jrblevin/markdown-mode/issues/635"
+  (markdown-test-string "| a | b \\| bb |
+| c | d |"
+    (search-forward "bb")
+    (markdown-table-delete-column)
+    (should (string= (buffer-string)
+                     "| a |
+| c |"))))
 
 ;;; gfm-mode tests:
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#635

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
