### PR TITLE
Fix executing markdown-table-sort-lines via menu bar issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,7 @@
     -   Fix list highlighting issue in code block [GH-631][]
     -   Fix exception when inserting code block at end of buffer [GH-634][]
     -   Fix table operations when table column contains escaped vertical bars [GH-635][]
+    -   Fix issue that executing `markdown-table-sort-lines` via menu-bar with older Emacs(< 28) [GH-641][]
 
   [gh-290]: https://github.com/jrblevin/markdown-mode/issues/290
   [gh-311]: https://github.com/jrblevin/markdown-mode/issues/311
@@ -101,6 +102,7 @@
   [gh-631]: https://github.com/jrblevin/markdown-mode/issues/631
   [gh-634]: https://github.com/jrblevin/markdown-mode/issues/634
   [gh-635]: https://github.com/jrblevin/markdown-mode/issues/635
+  [gh-641]: https://github.com/jrblevin/markdown-mode/issues/641
 
 # Markdown Mode 2.4
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9446,8 +9446,12 @@ indicate that sorting should be done in reverse order."
                         (t 1))))
         (sorting-type
          (or sorting-type
-             (read-char-exclusive
-              "Sort type: [a]lpha [n]umeric (A/N means reversed): "))))
+             (progn
+               ;; workaround #641
+               ;; Emacs < 28 hides prompt message by another message. This erases it.
+               (message "")
+               (read-char-exclusive
+                "Sort type: [a]lpha [n]umeric (A/N means reversed): ")))))
     (save-restriction
       ;; Narrow buffer to appropriate sorting area
       (if (region-active-p)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

This is Emacs issue and is fixed at Emacs 28

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#641

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
