### PR TITLE
Improve setext regexp for fill-paragraph

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9730,7 +9730,7 @@ rows and columns and the column alignment."
                            ;; not paragraph-ending suffixes:
                            ".*  $" ; line ending in two spaces
                            "^#+"
-                           "^[-=]+"
+                           "^\\(?:   \\)?[-=]+[ \t]*$" ;; setext
                            "[ \t]*\\[\\^\\S-*\\]:[ \t]*$") ; just the start of a footnote def
                          "\\|"))
   (setq-local adaptive-fill-first-line-regexp "\\`[ \t]*[A-Z]?>[ \t]*?\\'")

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5586,7 +5586,24 @@ Details: https://github.com/jrblevin/markdown-mode/issues/638"
 "))
     (markdown-test-string input
       (markdown-fill-paragraph)
-      (should (string= (buffer-string) input)))))
+      (should (string= (buffer-string) input))))
+  (let ((input "Heading
+-
+"))
+    (markdown-test-string input
+      (markdown-fill-paragraph)
+      (should (string= (buffer-string) input))))
+  ;; leading 3 spaces and trailing spaces is ok
+  (let ((input "Heading
+   ====     \t\n"))
+    (markdown-test-string input
+      (markdown-fill-paragraph)
+      (should (string= (buffer-string) input))))
+  ;; fill-paragraph is applied for list element
+  (markdown-test-string "- foo
+bar baz"
+    (markdown-fill-paragraph)
+    (should (string= (buffer-string) "- foo bar baz"))))
 
 ;;; Export tests:
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#645 https://github.com/jrblevin/markdown-mode/pull/645#discussion_r699260384
CC: @gbordyugov

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Improvement (non-breaking change which improves an existing feature)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
