### PR TITLE
Check both beginning/end of code block are valid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@
     -   Give `markdown-table-at-point-p-function` a non-nil default.
         Simplify `markdown-table-at-point-p` accordingly.
     -   Auto set `sh-shell` when `markdown-edit-code-block` enter indirect buffer with `sh-mode`
+    -   Add value check and avoid raising the exception at `markdown-edit-code-block` [GH-663][]
 
 *   Bug fixes:
     -   Fix issue with `nil` being returned from `markdown-imenu-create-nested-index` [GH-578][]
@@ -115,6 +116,7 @@
   [gh-641]: https://github.com/jrblevin/markdown-mode/issues/641
   [gh-649]: https://github.com/jrblevin/markdown-mode/issues/649
   [gh-652]: https://github.com/jrblevin/markdown-mode/issues/652
+  [gh-663]: https://github.com/jrblevin/markdown-mode/issues/663
 
 # Markdown Mode 2.4
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8797,7 +8797,8 @@ at the END of code blocks."
   (goto-char (- beg 1))
   (let ((block-indentation (current-indentation)))
     (when (> block-indentation 0)
-      (indent-rigidly beg end block-indentation))))
+      (indent-rigidly beg end block-indentation)))
+  (font-lock-ensure))
 
 (defun markdown-edit-code-block ()
   "Edit Markdown code block in an indirect buffer."
@@ -8805,8 +8806,8 @@ at the END of code blocks."
   (save-excursion
     (if (fboundp 'edit-indirect-region)
         (let* ((bounds (markdown-get-enclosing-fenced-block-construct))
-               (begin (and bounds (goto-char (nth 0 bounds)) (point-at-bol 2)))
-               (end (and bounds (goto-char (nth 1 bounds)) (point-at-bol 1))))
+               (begin (and bounds (not (null (nth 0 bounds))) (goto-char (nth 0 bounds)) (point-at-bol 2)))
+               (end (and bounds(not (null (nth 1 bounds)))  (goto-char (nth 1 bounds)) (point-at-bol 1))))
           (if (and begin end)
               (let* ((indentation (and (goto-char (nth 0 bounds)) (current-indentation)))
                      (lang (markdown-code-block-lang))
@@ -8816,7 +8817,7 @@ at the END of code blocks."
                       (lambda (_parent-buffer _beg _end)
                         (funcall mode)))
                      (indirect-buf (edit-indirect-region begin end 'display-buffer)))
-                  ;; reset `sh-shell' when indirect buffer
+                ;; reset `sh-shell' when indirect buffer
                 (when (and (not (member system-type '(ms-dos windows-nt)))
                            (member mode '(shell-script-mode sh-mode))
                            (member lang (append


### PR DESCRIPTION
Sometimes beginning of code block cannot be got while end of code
block can be got, then it causes error.

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#563, #663

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Improvement (non-breaking change which improves an existing feature)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
