### PR TITLE
extend markdown-do to follow links

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8222,9 +8222,6 @@ Jumps between reference links and definitions; between footnote
 markers and footnote text."
   (interactive)
   (cond
-   ;; Link
-   ((or (markdown-link-p) (markdown-wiki-link-p))
-    (markdown-follow-thing-at-point nil))
    ;; Footnote definition
    ((markdown-footnote-text-positions)
     (markdown-footnote-return))
@@ -8237,6 +8234,9 @@ markers and footnote text."
    ;; Reference definition
    ((thing-at-point-looking-at markdown-regex-reference-definition)
     (markdown-reference-goto-link (match-string-no-properties 2)))
+   ;; Link
+   ((or (markdown-link-p) (markdown-wiki-link-p))
+    (markdown-follow-thing-at-point nil))
    ;; GFM task list item
    ((markdown-gfm-task-list-item-at-point)
     (markdown-toggle-gfm-checkbox))

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -1558,6 +1558,33 @@ the opening bracket of [^2], and then subsequent functions would kill [^2])."
       (markdown-footnote-kill)
       (should (string-equal (current-kill 0) "foo\n")))))
 
+(ert-deftest test-markdown-do/jump-wikilink ()
+  "Test `markdown-do' jumps to wiki links"
+  (markdown-test-string
+      "[[Foo]]"
+    (goto-char 3) ; Foo
+    (markdown-do) ; open Foo.md
+    (should (string= (buffer-string) ""))))
+
+(ert-deftest test-markdown-do/jump-link ()
+  "Test `markdown-do' jumps to markdown links"
+  (markdown-test-string
+      "[bar](https://duckduckgo.com)"
+    (goto-char 3) ; Foo
+    (markdown-do) ; open browser
+    (should (string= (buffer-string) ""))))
+
+(ert-deftest test-markdown-do/wikilink-in-table ()
+  "Test `markdown-do' jumps to markdown links"
+  (markdown-test-string
+      "| [[Foo]]     |"
+    (goto-char 1) ; Table cell
+    (markdown-do) ; align
+    (should (string= (buffer-string) "| [[Foo]] |"))
+    (goto-char 4) ; Foo
+    (markdown-do) ; open Foo.md
+    (should (string= (buffer-string) "| [[Foo]] |"))))
+
 (ert-deftest test-markdown-footnote-reference/jump ()
   "Test `markdown-do' for footnotes and reference links."
   (markdown-test-string


### PR DESCRIPTION
motivation: spacemacs and others bind `<RET>` to
`markdown-do` in evil normal mode. 

with this change links can also be followed with enter.

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).