### PR TITLE
Check if not at eob in markdown-match-math-double

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2970,7 +2970,8 @@ $..$ or `markdown-regex-math-inline-double' for matching $$..$$."
 (defun markdown-match-math-double (last)
   "Match double quoted $$..$$ math from point to LAST."
   (when markdown-enable-math
-    (when (and (char-equal (char-after) ?$)
+    (when (and (< (1+ (point)) (point-max))
+               (char-equal (char-after) ?$)
                (char-equal (char-after (1+ (point))) ?$)
                (not (bolp))
                (not (char-equal (char-before) ?\\))

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5955,6 +5955,16 @@ Detail: https://github.com/jrblevin/markdown-mode/issues/352"
       (markdown-test-range-has-face 9 9 'markdown-math-face)
       (markdown-test-range-has-face 10 11 'markdown-markup-face))))
 
+(ert-deftest test-markdown-math/math-inline-small-buffer ()
+  "Test that font-lock parsing works with a single dollar."
+  (let ((markdown-enable-math t))
+    (markdown-test-string "$"
+      (should t))
+    (markdown-test-string "$$"
+      (should t))
+    (markdown-test-string "$$$"
+      (should t))))
+
 ;;; Extension: pipe table editing
 
 (ert-deftest test-markdown-table/table-begin-top-of-file ()


### PR DESCRIPTION
`markdown-match-math-double` breaks with `Wrong type argument: characterp, nil` when `$` is at the end of buffer. Add an explicit check for that. 