### PR TITLE
Adds space to fix marginalized ATX header rendering in tty mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@
     -   Add NonGNU ELPA badge to README and website
 
 *   Bug fixes:
+    -   Fix `markdown-marginalize-headers` rendering in tty mode
     -   Fix issue with `nil` being returned from `markdown-imenu-create-nested-index` [GH-578][]
     -   Fix remaining flyspell overlay in code block or comment issue [GH-311][]
     -   Fix inline URL regular expression which starts/ends with spaces [GH-514][]

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3383,7 +3383,7 @@ SEQ may be an atom or a sequence."
              (margin-char-width (/ margin-pixel-width (default-font-width))))
         (set-window-margins nil margin-char-width))
     ;; As a fallback, simply set margin based on character count.
-    (set-window-margins nil markdown-marginalize-headers-margin-width)))
+    (set-window-margins nil (1+ markdown-marginalize-headers-margin-width))))
 
 (defun markdown-fontify-headings (last)
   "Add text properties to headings from point to LAST."


### PR DESCRIPTION
This increases the left window margin size by 1, which is required so
that when emacs is running in tty mode, and marginalized headers 
is enabeld, there is a one character of whitespace between the left 
atx header chars and header text. This is the desired appearance 
and how it currently renders in GUI mode.

## Description

I contributed the work for the PR to add marginalized headers a few 
years ago but I did not notice that in tty the spacing was not quite 
right. This PR fixes that.

To be frank it's not clear to me why it was not necessary to add this
additional character width in GUI mode. I suspect it's because of
some default behaviors that govern GUI layout, which I am not
aware of.

Testing and stability:

I have tested this fix by visually inspecting the result on 
emacs 27.1 and emacs 27.2. I am not aware of how to do automated
testing on this sort of thing. This is a very small change and I am familiar
with the original code, having contributed to it, so I am pretty
confident this is safe.

I can submit screenshots to show before/after rendering if that is
of interest.

## Related Issue

I am unaware of related issues.

## Type of Change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).
