### PR TITLE
Fix fontification of repeated lists and tables

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3426,11 +3426,11 @@ SEQ may be an atom or a sequence."
     t))
 
 (defun markdown-fontify-tables (last)
-  (when (and (re-search-forward "|" last t)
-             (markdown-table-at-point-p))
-    (font-lock-append-text-property
-     (line-beginning-position) (min (1+ (line-end-position)) (point-max))
-     'face 'markdown-table-face)
+  (when (re-search-forward "|" last t)
+    (when (markdown-table-at-point-p)
+      (font-lock-append-text-property
+       (line-beginning-position) (min (1+ (line-end-position)) (point-max))
+       'face 'markdown-table-face))
     (forward-line 1)
     t))
 
@@ -3450,27 +3450,27 @@ SEQ may be an atom or a sequence."
 
 (defun markdown-fontify-list-items (last)
   "Apply font-lock properties to list markers from point to LAST."
-  (when (and (markdown-match-list-items last)
-             (not (markdown-code-block-at-point-p (match-beginning 2))))
-    (let* ((indent (length (match-string-no-properties 1)))
-           (level (/ indent markdown-list-indent-width)) ;; level = 0, 1, 2, ...
-           (bullet (nth (mod level (length markdown-list-item-bullets))
-                        markdown-list-item-bullets)))
-      (add-text-properties
-       (match-beginning 2) (match-end 2) '(face markdown-list-face))
-      (when markdown-hide-markup
-        (cond
-         ;; Unordered lists
-         ((string-match-p "[\\*\\+-]" (match-string 2))
-          (add-text-properties
-           (match-beginning 2) (match-end 2) `(display ,bullet)))
-         ;; Definition lists
-         ((string-equal ":" (match-string 2))
-          (let ((display-string
-                 (char-to-string (markdown--first-displayable
-                                  markdown-definition-display-char))))
-            (add-text-properties (match-beginning 2) (match-end 2)
-                                 `(display ,display-string)))))))
+  (when (markdown-match-list-items last)
+    (when (not (markdown-code-block-at-point-p (match-beginning 2)))
+      (let* ((indent (length (match-string-no-properties 1)))
+             (level (/ indent markdown-list-indent-width)) ;; level = 0, 1, 2, ...
+             (bullet (nth (mod level (length markdown-list-item-bullets))
+                          markdown-list-item-bullets)))
+        (add-text-properties
+         (match-beginning 2) (match-end 2) '(face markdown-list-face))
+        (when markdown-hide-markup
+          (cond
+           ;; Unordered lists
+           ((string-match-p "[\\*\\+-]" (match-string 2))
+            (add-text-properties
+             (match-beginning 2) (match-end 2) `(display ,bullet)))
+           ;; Definition lists
+           ((string-equal ":" (match-string 2))
+            (let ((display-string
+                   (char-to-string (markdown--first-displayable
+                                    markdown-definition-display-char))))
+              (add-text-properties (match-beginning 2) (match-end 2)
+                                   `(display ,display-string))))))))
     t))
 
 (defun markdown-fontify-hrs (last)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2795,6 +2795,19 @@ See https://github.com/jrblevin/markdown-mode/issues/631"
     (should-not (markdown-range-property-any 9 9 'face '(markdown-list-face)))
     (should-not (markdown-range-property-any 16 16 'face '(markdown-list-face)))))
 
+
+(ert-deftest test-markdown-font-lock/repeated-lists ()
+  "A simple definition list marker font lock test."
+  (markdown-test-file "repeated-elements.text"
+    (markdown-test-range-has-face 163 164 'markdown-list-face)
+    (markdown-test-range-has-face 190 191 'markdown-list-face)))
+
+(ert-deftest test-markdown-font-lock/repeated-tables ()
+  "A simple definition list marker font lock test."
+  (markdown-test-file "repeated-elements.text"
+    (markdown-test-range-has-face 149 155 nil)
+    (markdown-test-range-has-face 218 336 'markdown-table-face)))
+
 (ert-deftest test-markdown-font-lock/definition-list ()
   "A simple definition list marker font lock test."
   (markdown-test-file "definition-list.text"

--- a/tests/repeated-elements.text
+++ b/tests/repeated-elements.text
@@ -1,0 +1,23 @@
+Markdown Repeated Elements
+==========================
+
+```fortran
+* 
+PROGRAM EUCLID
+```
+
+1. This is an ordered list
+2. With a second element.
+
+fake |table| sfds
+
+1. This is an ordered list
+2. With a second element.
+
+
+| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |
+
+


### PR DESCRIPTION
Font lock keyword matchers have to return t as long as the matcher hasn't finished searching the region. Otherwise the matcher won't be called repeatedly to highlight multiple elements. I have identified 2 such issues, one for list and one for tables. Others seem to be fine, but I haven't got very deep into those. 