### PR TITLE
make `markdown` pass `buffer-file-name`  to `markdown-command` if needed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 *Under development*
 
+*   Improvements:
+    -   `markdown` passes `buffer-file-name` as a parameter to
+        `markdown-command` when `markdown-command-needs-filename` is
+        `t` and `markdown-command` is a function.
+
 # Markdown Mode 2.5
 
 *   **Breaking changes:**

--- a/README.md
+++ b/README.md
@@ -665,13 +665,16 @@ that can be customized.  The <kbd>M-x customize-mode</kbd> command
 provides an interface to all of the possible customizations:
 
   * `markdown-command` - the command used to run Markdown (default:
-    `markdown`).  This variable may be customized to pass
-    command-line options to your Markdown processor of choice. We recommend
-    you to use list of strings if you want to set command line options like.
+    `markdown`).  This variable may be customized to pass command-line
+    options to your Markdown processor of choice. We recommend you to
+    use list of strings if you want to set command line options like.
     `'("pandoc" "--from=markdown" "--to=html5")`.  It can also be a
     function; in this case `markdown` will call it with three
-    arguments: the beginning and end of the region to process, and
-    a buffer to write the output to.
+    arguments or four arguments, depending on
+    `markdown-command-needs-filename`.  The first three arguments are:
+    the beginning and end of the region to process, and a buffer to
+    write the output to. When `markdown-command-needs-filename` is `t`, the fourth
+    argument is set to the name of the file.
 
   * `markdown-command-needs-filename` - set to `t` if
     `markdown-command` does not accept standard input (default:
@@ -680,9 +683,7 @@ provides an interface to all of the possible customizations:
     When set to `t`, `markdown-mode` will pass the name of the file
     as the final command-line argument to `markdown-command`.  Note
     that in the latter case, you will only be able to run
-    `markdown-command` from buffers which are visiting a file.  If
-    `markdown-command` is a function, `markdown-command-needs-filename`
-    is ignored.
+    `markdown-command` from buffers which are visiting a file. 
 
   * `markdown-open-command` - the command used for calling a standalone
     Markdown previewer which is capable of opening Markdown source files

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7351,7 +7351,11 @@ Return the name of the output buffer used."
                      (if (not (null command-args))
                          (apply #'call-process-region begin-region end-region command nil buf nil command-args)
                        (call-process-region begin-region end-region command nil buf))
-                   (funcall markdown-command begin-region end-region buf)
+                   (if markdown-command-needs-filename
+                       (if (not buffer-file-name)
+                           (user-error "Must be visiting a file")
+                         (funcall markdown-command begin-region end-region buf buffer-file-name))
+                     (funcall markdown-command begin-region end-region buf))
                    ;; If the ‘markdown-command’ function didn’t signal an
                    ;; error, assume it succeeded by binding ‘exit-code’ to 0.
                    0))))))


### PR DESCRIPTION
This PR changes `markdown` to take `markdown-command-needs-filename` into account in the case where `markdown-command` is a function. Specifically, if `markdown-command-needs-filename` is `t`, `markdown` then passes `buffer-file-name` as the last parameter to `markdown-command`.

## Description

This change turns out to be necessary for using `markdown-mode` to render [quarto](https://quarto.org) documents. (I'm working on a `quarto-mode` that builds on `markdown-mode` through `poly-R`. So, thank you for `markdown-mode`, it's fantastic!) quarto doesn't `stdin` and needs information about the directory of the file in order to produce the right output. As a result, the easiest way to make this work is to pass the `buffer-file-name` information along.

## Related Issue

N/A.

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).

I haven't added a test to exercise this, but I have run the test suite on my changes, and the results are the same as before (there are three skipped tests, and just under 600 successes.)
