### PR TITLE
Set syntax of backtick to "string"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
     -   `markdown` passes `buffer-file-name` as a parameter to
         `markdown-command` when `markdown-command-needs-filename` is
         `t` and `markdown-command` is a function.
+    -   Set syntax of backtick to "string"
 
 # Markdown Mode 2.5
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3522,6 +3522,7 @@ SEQ may be an atom or a sequence."
 
 (defvar markdown-mode-syntax-table
   (let ((tab (make-syntax-table text-mode-syntax-table)))
+    (modify-syntax-entry ?` "\"" tab)
     (modify-syntax-entry ?\" "." tab)
     tab)
   "Syntax table for `markdown-mode'.")


### PR DESCRIPTION
Sets the syntax category of the backtick character to "string" (`"`). This reflects the actual Markdown syntax more accurately, and allows commands and modes which work on paired delimiters to work (e.g. `forward-sexp`, `electric-pair-mode`).

## Related Issue
https://github.com/jrblevin/markdown-mode/issues/695

Should also satisfy https://github.com/jrblevin/markdown-mode/issues/672

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).

