### PR TITLE
Drop Emacs 25.x support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,7 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 25.1
-          - 26.3
+          - 26.1
           - 27.2
           - 28.1
           - snapshot

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 *Under development*
 
+*   **Breaking changes:**
+    -   GNU Emacs 26.1 or later is required.
+
 *   Improvements:
     -   `markdown` passes `buffer-file-name` as a parameter to
         `markdown-command` when `markdown-command-needs-filename` is

--- a/README.md
+++ b/README.md
@@ -1065,7 +1065,7 @@ contributions!  See the [contributors graph][contrib] for details.
 ## Bugs
 
 markdown-mode is developed and tested primarily for compatibility
-with GNU Emacs 25.1 and later.  If you find any bugs in
+with GNU Emacs 26.1 and later.  If you find any bugs in
 markdown-mode, please construct a test case or a patch and open a
 ticket on the [GitHub issue tracker][issues].  See the
 contributing guidelines in `CONTRIBUTING.md` for details on

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Jason R. Blevins <jblevins@xbeta.org>
 ;; Created: May 24, 2007
 ;; Version: 2.6-dev
-;; Package-Requires: ((emacs "25.1"))
+;; Package-Requires: ((emacs "26.1"))
 ;; Keywords: Markdown, GitHub Flavored Markdown, itex
 ;; URL: https://jblevins.org/projects/markdown-mode/
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -29,11 +29,3 @@ html: $(TEST_HTML)
 
 clean:
 	rm -f $(TEST_HTML) *.elc ../*.elc
-
-evm:
-	$(MAKE) test EMACS="$(shell evm bin emacs-25.1)"
-	$(MAKE) test EMACS="$(shell evm bin emacs-25.2)"
-	$(MAKE) test EMACS="$(shell evm bin emacs-25.3)"
-	$(MAKE) test EMACS="$(shell evm bin emacs-26.1)"
-	$(MAKE) test EMACS="$(shell evm bin emacs-26.2)"
-	$(MAKE) test EMACS="$(shell evm bin emacs-26.3)"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

Emacs 28.1 has been released. So we drop Emacs 25 support for maintenance cost

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
