### PR TITLE
Handle escaping backslashes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
     -   `markdown` passes `buffer-file-name` as a parameter to
         `markdown-command` when `markdown-command-needs-filename` is
         `t` and `markdown-command` is a function.
+    -   Highlight bachslashes which escape Markdown elements, and make it
+        hidden in `*-view-mode` [GH-377][]
 
 # Markdown Mode 2.5
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -928,6 +928,12 @@ Group 3 matches the mathematical expression contained within.
 Group 2 matches the opening slashes, and is used internally to
 match the closing slashes.")
 
+(defconst markdown-regex-escaped-char
+  "\\(?1:\\\\\\)\\(?2:[-~_.*\\\\]\\)"
+  "Regular expression for escaped character.
+Group 1 matches leading backslash.
+Group 2 matches the escaped character.")
+
 (defsubst markdown-make-tilde-fence-regex (num-tildes &optional end-of-line)
   "Return regexp matching a tilde code fence at least NUM-TILDES long.
 END-OF-LINE is the regexp construct to indicate end of line; $ if
@@ -1774,6 +1780,10 @@ START and END delimit region to propertize."
   '(face markdown-link-title-face invisible markdown-markup)
   "List of properties and values to apply to included code titles.")
 
+(defconst markdown-escape-char-properties
+  '(face markdown-escape-char-face invisible markdown-markup)
+  "List of properties and values to apply to escape characters.")
+
 (defcustom markdown-hide-markup nil
   "Determines whether markup in the buffer will be hidden.
 When set to nil, all markup is displayed in the buffer as it
@@ -2010,6 +2020,11 @@ For example, this applies to plain angle bracket URLs:
   "Face for highlighting."
   :group 'markdown-faces)
 
+(defface markdown-escape-char-face
+  '((t (:inherit font-lock-comment-face)))
+  "Face for escape character."
+  :group 'markdown-faces)
+
 (defcustom markdown-header-scaling nil
   "Whether to use variable-height faces for headers.
 When non-nil, `markdown-header-face' will inherit from
@@ -2210,7 +2225,8 @@ Depending on your font, some reasonable choices are:
     (markdown-match-inline-attributes . ((0 markdown-markup-properties prepend)))
     (markdown-match-leanpub-sections . ((0 markdown-markup-properties)))
     (markdown-fontify-blockquotes)
-    (markdown-match-wiki-link . ((0 'markdown-link-face prepend))))
+    (markdown-match-wiki-link . ((0 'markdown-link-face prepend)))
+    (,markdown-regex-escaped-char . ((1 markdown-escape-char-properties))))
   "Syntax highlighting for Markdown files.")
 
 ;; Footnotes

--- a/tests/escape.txt
+++ b/tests/escape.txt
@@ -1,0 +1,5 @@
+\_foo\_
+
+\* list item 1
+
+\- list item 2

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2224,6 +2224,19 @@ See GH-245."
       (should (invisible-p 154))
       (should (invisible-p 156)))))
 
+(ert-deftest test-markdown-markup-hiding/escape-1 ()
+  "Test hiding markup for escape."
+  (let ((markdown-hide-markup t))
+    (markdown-test-file "escape.txt"
+      (markdown-test-range-has-property 1 1 'invisible 'markdown-markup)
+      (markdown-test-range-has-property 10 10 'invisible 'markdown-markup)
+      (markdown-test-range-has-property 26 26 'invisible 'markdown-markup)
+      (should (invisible-p 1)) ;; leading backslash
+      (should-not (invisible-p 2)) ;; an escaped character
+      (should-not (invisible-p 3)) ;; inside escped markdown element
+      (should (invisible-p 10))
+      (should (invisible-p 26)))))
+
 ;;; Markup hiding url tests:
 
 (ert-deftest test-markdown-url-hiding/eldoc ()
@@ -2262,7 +2275,9 @@ Detail: https://github.com/jrblevin/markdown-mode/pull/674"
   "Test that slash inside asterisks is not italic."
   (markdown-test-string
       "not italic *\\*"
-    (markdown-test-range-has-face (point-min) (point-max) nil)))
+    (markdown-test-range-has-face (point-min) (+ 11 (point-min)) nil)
+    (markdown-test-range-has-face (+ 12 (point-min)) (+ 12 (point-min)) 'markdown-escape-char-face)
+    (markdown-test-range-has-face (+ 13 (point-min)) (+ 13 (point-min)) nil)))
 
 (ert-deftest test-markdown-font-lock/italics-4 ()
   "Test escaped asterisk inside italics."
@@ -3663,6 +3678,14 @@ across blocks]"
       (markdown-test-range-has-face 6 7 'markdown-markup-face)))
   (markdown-test-string "==foo=="
     (markdown-test-range-has-face 1 7 nil)))
+
+(ert-deftest test-markdown-font-lock/escape ()
+  "Test font-lock for escape"
+  (markdown-test-string "\\_foo\\_"
+    (markdown-test-range-face-equals 1 1 'markdown-escape-char-face) ;; leading backslash
+    (markdown-test-range-face-equals 2 5 nil) ;; an escaped char and inside escaped markdown element
+    (markdown-test-range-face-equals 6 6 'markdown-escape-char-face) ;; backslash
+    (markdown-test-range-face-equals 7 7 nil))) ;; trailing underscore
 
 ;;; Markdown Parsing Functions:
 


### PR DESCRIPTION
## Description

This patch highlights backslashes which escape another Markdown element.
Also, this make backslash hidden if `markdown-hide-markup` is `t`.

If you don't prefer highlighting backslash with comment face, I can change the face.

## Related Issue

#377 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
