### PR TITLE
Introduce markdown-fontify-whole-heading-line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,10 +5,16 @@
 *   **Breaking changes:**
     -   GNU Emacs 26.1 or later is required.
 
+*   New Feature:
+    - Introduce `markdown-fontify-whole-heading-line` variable for highlighting
+      whole header line. [GH-705][]
+
 *   Improvements:
     -   `markdown` passes `buffer-file-name` as a parameter to
         `markdown-command` when `markdown-command-needs-filename` is
         `t` and `markdown-command` is a function.
+
+  [gh-705]: https://github.com/jrblevin/markdown-mode/issues/705
 
 # Markdown Mode 2.5
 

--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ provides an interface to all of the possible customizations:
     When set to `t`, `markdown-mode` will pass the name of the file
     as the final command-line argument to `markdown-command`.  Note
     that in the latter case, you will only be able to run
-    `markdown-command` from buffers which are visiting a file. 
+    `markdown-command` from buffers which are visiting a file.
 
   * `markdown-open-command` - the command used for calling a standalone
     Markdown previewer which is capable of opening Markdown source files
@@ -913,6 +913,9 @@ provides an interface to all of the possible customizations:
 
   * `markdown-enable-highlighting-syntax` - font lock for highlighting
      syntax like Obsidian, Quilt(default: `nil`).
+
+  * `markdown-fontify-whole-heading-line` - font lock for highlighting
+     the whole line for headings.(default: `nil`)
 
 Additionally, the faces used for syntax highlighting can be modified to
 your liking by issuing <kbd>M-x customize-group RET markdown-faces</kbd>

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -637,6 +637,15 @@ This variable must be set before loading markdown-mode."
   :safe 'booleanp
   :package-version '(markdown-mode . "2.5"))
 
+(defcustom markdown-fontify-whole-heading-line nil
+  "Non-nil means fontify the whole line for headings.
+This is useful when setting a background color for the
+markdown-header-face-* faces."
+  :group 'markdown
+  :type 'boolean
+  :safe 'booleanp
+  :package-version '(markdown-mode . "2.5"))
+
 
 ;;; Markdown-Specific `rx' Macro ==============================================
 
@@ -3426,13 +3435,17 @@ SEQ may be an atom or a sequence."
                    (add-text-properties
                     (match-beginning 3) (match-end 3) rule-props)))
         ;; atx heading
-        (add-text-properties
-         (match-beginning 4) (match-end 4) left-markup-props)
-        (add-text-properties
-         (match-beginning 5) (match-end 5) heading-props)
-        (when (match-end 6)
+        (if markdown-fontify-whole-heading-line
+            (let ((header-end (min (point-max) (1+ (match-end 0)))))
+              (add-text-properties
+               (match-beginning 0) header-end heading-props))
           (add-text-properties
-           (match-beginning 6) (match-end 6) right-markup-props))))
+           (match-beginning 4) (match-end 4) left-markup-props)
+          (add-text-properties
+           (match-beginning 5) (match-end 5) heading-props)
+          (when (match-end 6)
+            (add-text-properties
+             (match-beginning 6) (match-end 6) right-markup-props)))))
     t))
 
 (defun markdown-fontify-tables (last)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2948,6 +2948,14 @@ puts markdown.to_html
   (markdown-test-string "###"
     (markdown-test-range-has-face 1 3 nil)))
 
+(ert-deftest test-markdown-font-lock/atx-whole-line ()
+  "Test font-lock for atx headers with whole line flag."
+  (let ((markdown-fontify-whole-heading-line t))
+    (markdown-test-string "## abc  "
+      (markdown-test-range-has-face 1 8 'markdown-header-face-2))
+    (markdown-test-string "## abc ##"
+      (markdown-test-range-has-face 1 9 'markdown-header-face-2))))
+
 (ert-deftest test-markdown-font-lock/setext-1-letter ()
   "An edge case for level-one setext headers."
   (markdown-test-string "a\n=\n"


### PR DESCRIPTION
## Description

<!-- More detailed description of the changes if needed. -->

Add customize variable `markdown-fontify-whole-heading-line` which is like `org-fontify-whole-heading-line`. This is useful when users set background color of `markdown-header-face-*` as below.

```elisp
(setq markdown-fontify-whole-heading-line t)
(set-face-attribute 'markdown-header-face-1 nil :extend t :background "green" :foreground "black")
(set-face-attribute 'markdown-header-face-2 nil :extend t :background "pink" :foreground "black")
```

![image](https://user-images.githubusercontent.com/554281/167251379-1a4c7c1a-1beb-49a2-b748-2693a76b9d77.png)

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

https://github.com/jrblevin/markdown-mode/issues/705 CC: @cyrus-and

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
