### PR TITLE
Support newer version Eldoc ships with Emacs 28

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
     -   `markdown` passes `buffer-file-name` as a parameter to
         `markdown-command` when `markdown-command-needs-filename` is
         `t` and `markdown-command` is a function.
+    -   Support newer version Eldoc ships with Emacs 28.
 
   [gh-705]: https://github.com/jrblevin/markdown-mode/issues/705
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9663,7 +9663,7 @@ rows and columns and the column alignment."
 
 ;;; ElDoc Support =============================================================
 
-(defun markdown-eldoc-function ()
+(defun markdown-eldoc-function (&optional _callback &rest _args)
   "Return a helpful string when appropriate based on context.
 * Report URL when point is at a hidden URL.
 * Report language name when point is a code block with hidden markup."
@@ -9803,8 +9803,10 @@ rows and columns and the column alignment."
   ;; Cause use of ellipses for invisible text.
   (add-to-invisibility-spec '(outline . t))
   ;; ElDoc support
-  (add-function :before-until (local 'eldoc-documentation-function)
-                #'markdown-eldoc-function)
+  (if (boundp 'eldoc-documentation-functions)
+      (add-hook 'eldoc-documentation-functions #'markdown-eldoc-function nil t)
+    (add-function :before-until (local 'eldoc-documentation-function)
+                  #'markdown-eldoc-function))
   ;; Inhibiting line-breaking:
   ;; Separating out each condition into a separate function so that users can
   ;; override if desired (with remove-hook)


### PR DESCRIPTION
This PR changes to use `eldoc-documentation-functions` instead of `eldoc-documentation-function` if available.

## Description

Emacs28 now ships with Eldoc 1.11.

The new Eldoc can have multiple backends available in `eldoc-documentation-functions`, and user can customize how they are displayed in `eldoc-documentation-strategy`.

For compatibility, `eldoc-documentation-function` are still available, but this change gives users the convenience of the new Eldoc.

Functions added to `eldoc-documentation-functions` require a `callback` argument, but they can return a value without use it, I think that this change is sufficient in Markdown Mode. Please refer to [docstring of eldoc-documentation-functions](https://github.com/emacs-mirror/emacs/blob/5a223c7f2ef4c31abbd46367b6ea83cd19d30aa7/lisp/emacs-lisp/eldoc.el#L386).

## Related Issue

No issue.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
