### PR TITLE
Fix functions with multiple docstrings

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7678,20 +7678,18 @@ displaying the rendered output."
          (setq markdown-live-preview-source-buffer nil))))
 
 (defun markdown-live-preview-switch-to-output ()
-  "Switch to output buffer."
-  (interactive)
   "Turn on `markdown-live-preview-mode' if not already on, and switch to its
 output buffer in another window."
+  (interactive)
   (if markdown-live-preview-mode
       (markdown-display-buffer-other-window (markdown-live-preview-export)))
   (markdown-live-preview-mode))
 
 (defun markdown-live-preview-re-export ()
-  "Re export source buffer."
-  (interactive)
   "If the current buffer is a buffer displaying the exported version of a
 `markdown-live-preview-mode' buffer, call `markdown-live-preview-export' and
 update this buffer's contents."
+  (interactive)
   (when markdown-live-preview-source-buffer
     (with-current-buffer markdown-live-preview-source-buffer
       (markdown-live-preview-export))))


### PR DESCRIPTION
## Description

A function should have a single docstring.  There are two functions that have two docstrings each, for each of these functions I remove one of the docstring.  In both cases the bad docstring was in the correct place, so I don't only remove the bad docstring, I also move the good docstring to the correct location.

(Actually the "good docstrings" aren't that great either.  The first line of a docstring should end with a period.  I have not fixed this.)

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have read the **CONTRIBUTING.md** document.
- [X] *Not necessary* I have updated the documentation in the **README.md** file if necessary.
- [X] *I.e. not necessary* I have added an entry to **CHANGES.md**.
- [X] *I.e. not necessary* I have added tests to cover my changes.
- [X] All new and existing tests passed (using `make test`).

## PS

Do I have your permission to forgo filling out this questionnaire for equally trivial fixes in the future?