### PR TITLE
WIP: add function to search for files with extensions

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -601,7 +601,10 @@ use its return value instead of the filename in the link.  For
 example, if absolute filenames are actually relative to a server
 root directory, you can set
 `markdown-translate-filename-function' to a function that
-prepends the root directory to the given filename."
+prepends the root directory to the given filename. Another
+example would be to set this to
+`markdown-search-file-with-extension` which will find a given
+filename but also filename.md."
   :group 'markdown
   :type 'function
   :risky t
@@ -7724,6 +7727,16 @@ update this buffer's contents."
 
 
 ;;; Links =====================================================================
+
+(defun markdown-search-file-with-extension (file)
+  "Search for a file named FILE but also common markdown extensions."
+  (if (file-exists-p file)
+      file
+    (cl-loop for extension in '("mdown" "mkd" "md" "markdown")
+             for md-file = (concat file "." extension)
+             when (file-exists-p md-file)
+             return md-file
+             finally return file)))
 
 (defun markdown-backward-to-link-start ()
   "Backward link start position if current position is in link title."


### PR DESCRIPTION
## Description

This adds a small function (actually written by @syohex) to search for
files named with common markdown suffixes.

It's not enabled by default, but suggested in the
`markdown-translate-filename-function` help.

I'm starting to wonder if the extension list should be a defcustom, because we also use it in the auto-alist thing... I also haven't completed the work here: we probably need tests, but i'm not familiar with that part of the project. :/

## Related Issue

Closes: #713

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).
