### PR TITLE
Improve docstrings

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -188,7 +188,7 @@ line around the header title."
 
 (defcustom markdown-indent-on-enter t
   "Determines indentation behavior when pressing \\[newline].
-Possible settings are nil, t, and `indent-and-new-item'.
+Possible settings are nil, t, and \\='indent-and-new-item.
 
 When non-nil, pressing \\[newline] will call `newline-and-indent'
 to indent the following line according to the context using
@@ -196,7 +196,7 @@ to indent the following line according to the context using
 \\[electric-newline-and-maybe-indent] can still be used to insert
 a newline without indentation.
 
-When set to `indent-and-new-item' and the point is in a list item
+When set to \\='indent-and-new-item and the point is in a list item
 when \\[newline] is pressed, the list will be continued on the next
 line, where a new item will be inserted.
 
@@ -490,15 +490,15 @@ completion."
 
 (defcustom markdown-split-window-direction 'any
   "Preference for splitting windows for static and live preview.
-The default value is `any', which instructs Emacs to use
+The default value is \\='any, which instructs Emacs to use
 `split-window-sensibly' to automatically choose how to split
 windows based on the values of `split-width-threshold' and
 `split-height-threshold' and the available windows.  To force
-vertically split (left and right) windows, set this to `vertical'
-or `right'.  To force horizontally split (top and bottom) windows,
-set this to `horizontal' or `below'.
+vertically split (left and right) windows, set this to \\='vertical
+or \\='right.  To force horizontally split (top and bottom) windows,
+set this to \\='horizontal or \\='below.
 
-If this value is `any' and `display-buffer-alist' is set then
+If this value is \\='any and `display-buffer-alist' is set then
 `display-buffer' is used for open buffer function"
   :group 'markdown
   :type '(choice (const :tag "Automatic" any)
@@ -516,8 +516,8 @@ the buffer."
 
 (defcustom markdown-live-preview-delete-export 'delete-on-destroy
   "Delete exported HTML file when using `markdown-live-preview-export'.
-If set to `delete-on-export', delete on every export. When set to
-`delete-on-destroy' delete when quitting from command
+If set to \\='delete-on-export, delete on every export. When set to
+\\='delete-on-destroy delete when quitting from command
 `markdown-live-preview-mode'. Never delete if set to nil."
   :group 'markdown
   :type '(choice
@@ -864,7 +864,7 @@ Group 3 matches the text.")
 (defconst markdown-regex-wiki-link
   "\\(?:^\\|[^\\]\\)\\(?1:\\(?2:\\[\\[\\)\\(?3:[^]|]+\\)\\(?:\\(?4:|\\)\\(?5:[^]]+\\)\\)?\\(?6:\\]\\]\\)\\)"
   "Regular expression for matching wiki links.
-This matches typical bracketed [[WikiLinks]] as well as `aliased'
+This matches typical bracketed [[WikiLinks]] as well as \\='aliased
 wiki links of the form [[PageName|link text]].
 The meanings of the first and second components depend
 on the value of `markdown-wiki-link-alias-first'.
@@ -1344,7 +1344,7 @@ block construct when it is matched using
 to the text matching START-REGEX-OR-FUN, END-PROPERTY to END-REGEX-OR-FUN, and
 MIDDLE-PROPERTY to the text in between the two. The value of *-PROPERTY is the
 `match-data' when the regexp was matched to the text. In the case of
-MIDDLE-PROPERTY, the value is a false match data of the form `(begin end)', with
+MIDDLE-PROPERTY, the value is a false match data of the form \\='(begin end), with
 begin and end set to the edges of the \"middle\" text. This makes fontification
 easier.")
 
@@ -2647,7 +2647,7 @@ The return value has the same form as that of
 
 (defun markdown-bounds-of-thing-at-point (thing)
   "Call `bounds-of-thing-at-point' for THING with slight modifications.
-Does not include trailing newlines when THING is `line'.  Handles the
+Does not include trailing newlines when THING is \\='line.  Handles the
 end of buffer case by setting both endpoints equal to the value of
 `point-max', since an empty region will trigger empty markup insertion.
 Return bounds of form (beg . end) if THING is found, or nil otherwise."
@@ -3028,13 +3028,13 @@ Restore match data previously stored in PROPERTY."
 
 (defun markdown-match-pre-blocks (last)
   "Match preformatted blocks from point to LAST.
-Use data stored in `markdown-pre' text property during syntax
+Use data stored in \\='markdown-pre text property during syntax
 analysis."
   (markdown-match-propertized-text 'markdown-pre last))
 
 (defun markdown-match-gfm-code-blocks (last)
   "Match GFM quoted code blocks from point to LAST.
-Use data stored in `markdown-gfm-code' text property during syntax
+Use data stored in \\='markdown-gfm-code text property during syntax
 analysis."
   (markdown-match-propertized-text 'markdown-gfm-code last))
 
@@ -3056,7 +3056,7 @@ analysis."
 
 (defun markdown-match-blockquotes (last)
   "Match blockquotes from point to LAST.
-Use data stored in `markdown-blockquote' text property during syntax
+Use data stored in \\='markdown-blockquote text property during syntax
 analysis."
   (markdown-match-propertized-text 'markdown-blockquote last))
 
@@ -4982,7 +4982,7 @@ If the point is at a table, move to the next row.  Otherwise,
 indent according to value of `markdown-indent-on-enter'.
 When it is nil, simply call `newline'.  Otherwise, indent the next line
 following RET using `markdown-indent-line'.  Furthermore, when it
-is set to `indent-and-new-item' and the point is in a list item,
+is set to \\='indent-and-new-item and the point is in a list item,
 start a new item with the same indentation. If the point is in an
 empty list item, remove it (so that pressing RET twice when in a
 list simply adds a blank line)."


### PR DESCRIPTION
Use escaped single quote for symbols in docstring

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

I fixed docstring in #712 only for CI error(byte-compile warnings). This fix is more preferable fix.

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Improvement (non-breaking change which improves an existing feature)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
