### PR TITLE
Reset `markdown-code-fontification` to be flagged as unmodified

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,11 +18,12 @@
 
 *   Bug fixes:
     - Don't override table faces by link faces [GH-716][]
+    - Stop `save-some-buffers` from saving `markdown-code-fontification` buffers [GH-719][]
 
   [gh-572]: https://github.com/jrblevin/markdown-mode/issues/572
   [gh-705]: https://github.com/jrblevin/markdown-mode/issues/705
   [gh-716]: https://github.com/jrblevin/markdown-mode/issues/716
-
+  [gh-719]: https://github.com/jrblevin/markdown-mode/issues/719
 
 # Markdown Mode 2.5
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8815,7 +8815,8 @@ position."
                 (put-text-property
                  (+ start (1- pos)) (1- (+ start next)) 'face
                  val markdown-buffer)))
-            (setq pos next)))
+            (setq pos next))
+          (set-buffer-modified-p nil)) ;; disable `save-some-buffers'
         (add-text-properties
          start end
          '(font-lock-fontified t fontified t font-lock-multiline t))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

`save-some-buffers` grabs the buffer because it's being modified, and
we get some annoying requests to save the buffer. By resetting the
modified flag, emacs doesn't try to save it.

<!-- More detailed description of the changes if needed. -->

Fix for:
https://github.com/jrblevin/markdown-mode/issues/719

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

Bug Fix

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).
