### PR TITLE
Fixes bug related to interaction with emacs's native compilation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,10 +18,13 @@
 
 *   Bug fixes:
     - Don't override table faces by link faces [GH-716][]
+    - Don't bytecompile symbol unless it's required for imenu based
+      functions. This fixes [mt-51][]
 
   [gh-572]: https://github.com/jrblevin/markdown-mode/issues/572
   [gh-705]: https://github.com/jrblevin/markdown-mode/issues/705
   [gh-716]: https://github.com/jrblevin/markdown-mode/issues/716
+  [mt-51]: https://github.com/ardumont/markdown-toc/issues/51
 
 
 # Markdown Mode 2.5

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9765,8 +9765,8 @@ rows and columns and the column alignment."
   ;; For imenu support
   (setq imenu-create-index-function
         (if markdown-nested-imenu-heading-index
-            #'markdown-imenu-create-nested-index
-          #'markdown-imenu-create-flat-index))
+            'markdown-imenu-create-nested-index
+          'markdown-imenu-create-flat-index))
 
   ;; Defun movement
   (setq-local beginning-of-defun-function #'markdown-beginning-of-defun)


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

## Description

This change specifically fixes this bug for me:
https://github.com/ardumont/markdown-toc/issues/51

IIUC, `#` is used to inform the byte-compiler that the expression can
be byte-compiled. But in this case there is nothing to compile since
it's a symbol.

## Related Issue

https://github.com/ardumont/markdown-toc/issues/51

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
