### PR TITLE
Consider character width to display horizontal rule in markdown-view-mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
     - Fix invalid italic fontification after bold markups[GH-731][]
     - Fix `markdown-live-preview-mode` fails when `eww-auto-rename-buffer` is non-nil[GH-737][]
     - Fix to mistake to handle the line as delimiter row[GH-747][]
+    - Fix wrong displaying horizontal rule in `markdown-view-mode` [GH-747][]
 
   [gh-572]: https://github.com/jrblevin/markdown-mode/issues/572
   [gh-705]: https://github.com/jrblevin/markdown-mode/issues/705
@@ -35,6 +36,7 @@
   [gh-739]: https://github.com/jrblevin/markdown-mode/issues/739
   [gh-743]: https://github.com/jrblevin/markdown-mode/issues/743
   [gh-747]: https://github.com/jrblevin/markdown-mode/issues/747
+  [gh-753]: https://github.com/jrblevin/markdown-mode/issues/753
 
 
 # Markdown Mode 2.5

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3507,14 +3507,14 @@ SEQ may be an atom or a sequence."
 (defun markdown-fontify-hrs (last)
   "Add text properties to horizontal rules from point to LAST."
   (when (markdown-match-hr last)
-    (let ((hr-char (markdown--first-displayable markdown-hr-display-char)))
+    (let* ((hr-char (markdown--first-displayable markdown-hr-display-char))
+           (hr-len (and hr-char (/ (window-max-chars-per-line) (char-width hr-char)))))
       (add-text-properties
        (match-beginning 0) (match-end 0)
        `(face markdown-hr-face
               font-lock-multiline t
               ,@(when (and markdown-hide-markup hr-char)
-                  `(display ,(make-string
-                              (1- (window-body-width)) hr-char)))))
+                  `(display ,(make-string hr-len hr-char)))))
       t)))
 
 (defun markdown-fontify-sub-superscripts (last)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5241,7 +5241,7 @@ Sentence seven. Sentence eight.
     (forward-sentence 1)
     (looking-back "seven\\." (line-beginning-position))
     (forward-sentence 1)
-    (looking-at-p "$")))
+    (should (looking-at-p "$"))))
 
 ;;; Link tests:
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

The width of separator character which is used to display horizontal rule is 2 in CJK language settings(Chinese, Korean, Japanese etc), so markdown-mode should consider its character width.

```lisp
(set-language-environment "Japanese")
(char-width #x2500) ;; => 2

(set-language-environment "English")
(char-width #x2500) ;; => 1
```

### Original version

![image](https://user-images.githubusercontent.com/554281/223123416-a4e39f03-87fe-4ce3-b778-e45efa96d489.png)

### This PR version

![image](https://user-images.githubusercontent.com/554281/223123245-4991225e-c014-429f-b60a-49c61400a738.png)

### Note

![image](https://user-images.githubusercontent.com/554281/223124277-2bdbe511-4460-49b2-871d-ba6e4b03b16d.png)

CJK users should set terminal configuration of ambiguous character width correctly. For example Gnome Terminal, set `Ambiguous-Width Characters` to `Wide`. If not, it looks like as below, the separator line is  too short. Because `char-width` returns 2(full-width) but display width is 1(half-width).

![image](https://user-images.githubusercontent.com/554281/223125154-6ccbf620-4442-48a9-911f-c0edb4242c3b.png)

If your terminal does not support CJK ambiguous characters, then you should remove such characters from `markdown-hr-display-char` like

```lisp
(setq markdown-hr-display-char '(?-))
```

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#753

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).

This is difficult to test
