### PR TITLE
Treat a backslash escape as a markup character

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,10 @@
 *   **Breaking changes:**
     -   GNU Emacs 26.1 or later is required.
 
-*   New Feature:
+*   New Features:
     - Introduce `markdown-fontify-whole-heading-line` variable for highlighting
       whole header line. [GH-705][]
+    - Backslashes in escape sequences are now treated as markup. [GH-377][]
 
 *   Improvements:
     - `markdown` passes `buffer-file-name` as a parameter to
@@ -28,6 +29,7 @@
     - Fix to mistake to handle the line as delimiter row[GH-747][]
     - Fix wrong displaying horizontal rule in `markdown-view-mode` [GH-747][]
 
+  [gh-377]: https://github.com/jrblevin/markdown-mode/issues/377
   [gh-572]: https://github.com/jrblevin/markdown-mode/issues/572
   [gh-705]: https://github.com/jrblevin/markdown-mode/issues/705
   [gh-716]: https://github.com/jrblevin/markdown-mode/issues/716

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -861,6 +861,10 @@ Group 3 matches the text.")
   "[^ \n\t][ \t]*\\(  \\)\n"
   "Regular expression for matching line breaks.")
 
+(defconst markdown-regex-escape
+  "\\(\\\\\\)."
+  "Regular expression for matching escape sequences.")
+
 (defconst markdown-regex-wiki-link
   "\\(?:^\\|[^\\]\\)\\(?1:\\(?2:\\[\\[\\)\\(?3:[^]|]+\\)\\(?:\\(?4:|\\)\\(?5:[^]]+\\)\\)?\\(?6:\\]\\]\\)\\)"
   "Regular expression for matching wiki links.
@@ -2216,6 +2220,7 @@ Depending on your font, some reasonable choices are:
                                      (4 'markdown-highlighting-face)
                                      (5 markdown-markup-properties)))
     (,markdown-regex-line-break . (1 'markdown-line-break-face prepend))
+    (,markdown-regex-escape . ((1 markdown-markup-properties prepend)))
     (markdown-fontify-sub-superscripts)
     (markdown-match-inline-attributes . ((0 markdown-markup-properties prepend)))
     (markdown-match-leanpub-sections . ((0 markdown-markup-properties)))

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2225,6 +2225,16 @@ See GH-245."
       (should (invisible-p 154))
       (should (invisible-p 156)))))
 
+(ert-deftest test-markdown-markup-hiding/escape ()
+  "Test hiding markup for backslash escapes."
+  (markdown-test-string "\\#"
+    (markdown-test-range-has-property (point) (point) 'invisible 'markdown-markup)
+    (should-not (invisible-p (point)))
+    (should-not (invisible-p (1+ (point))))
+    (markdown-toggle-markup-hiding t)
+    (should (invisible-p (point)))
+    (should-not (invisible-p (1+ (point))))))
+
 ;;; Markup hiding url tests:
 
 (ert-deftest test-markdown-url-hiding/eldoc ()
@@ -2263,7 +2273,10 @@ Detail: https://github.com/jrblevin/markdown-mode/pull/674"
   "Test that slash inside asterisks is not italic."
   (markdown-test-string
       "not italic *\\*"
-    (markdown-test-range-has-face (point-min) (point-max) nil)))
+    (markdown-test-range-has-face 1 12 nil)
+    ;; Check face of the backslash
+    (markdown-test-range-has-face 13 13 'markdown-markup-face)
+    (markdown-test-range-has-face 14 14 nil)))
 
 (ert-deftest test-markdown-font-lock/italics-4 ()
   "Test escaped asterisk inside italics."
@@ -2656,10 +2669,17 @@ Detail: https://github.com/jrblevin/markdown-mode/issues/743"
     (markdown-test-range-has-face 461 467 'markdown-inline-code-face)
     (markdown-test-range-has-face 468 468 'markdown-markup-face)
     ;; Escaping of leading backquotes
-    (markdown-test-range-has-face 586 592 nil)
-    (markdown-test-range-has-face 597 603 nil)
+    (markdown-test-range-has-face 586 586 'markdown-markup-face)
+    (markdown-test-range-has-face 587 590 nil)
+    (markdown-test-range-has-face 591 591 'markdown-markup-face)
+    (markdown-test-range-has-face 592 592 nil)
+    (markdown-test-range-has-face 597 597 'markdown-markup-face)
+    (markdown-test-range-has-face 598 601 nil)
+    (markdown-test-range-has-face 602 602 'markdown-markup-face)
+    (markdown-test-range-has-face 603 603 nil)
     ;; A code span crossing lines
-    (markdown-test-range-has-face 652 656 nil)
+    (markdown-test-range-has-face 652 652 'markdown-markup-face)
+    (markdown-test-range-has-face 653 656 nil)
     (markdown-test-range-has-face 657 657 'markdown-markup-face)
     (markdown-test-range-has-face 658 665 'markdown-inline-code-face)
     (markdown-test-range-has-face 666 666 'markdown-markup-face)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

This ensures that when using `markdown-hide-markup`, escape sequences are properly unescaped.

## Related Issue

This resolves issue #377.

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] **(N/A)** I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
