### PR TITLE
Escape title

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
     - Fix `markdown-live-preview-mode` fails when `eww-auto-rename-buffer` is non-nil[GH-737][]
     - Fix to mistake to handle the line as delimiter row[GH-747][]
     - Fix wrong displaying horizontal rule in `markdown-view-mode` [GH-747][]
+    - HTML-escape title in `markdown-add-xhtml-header-and-footer` [GH-748][]
 
   [gh-377]: https://github.com/jrblevin/markdown-mode/issues/377
   [gh-572]: https://github.com/jrblevin/markdown-mode/issues/572
@@ -40,6 +41,7 @@
   [gh-743]: https://github.com/jrblevin/markdown-mode/issues/743
   [gh-747]: https://github.com/jrblevin/markdown-mode/issues/747
   [gh-753]: https://github.com/jrblevin/markdown-mode/issues/753
+  [gh-754]: https://github.com/cfclrk/markdown-xwidget/issues/9
 
 
 # Markdown Mode 2.5

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Jason R. Blevins <jblevins@xbeta.org>
 ;; Created: May 24, 2007
 ;; Version: 2.6-alpha
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "26.1") (compat "28"))
 ;; Keywords: Markdown, GitHub Flavored Markdown, itex
 ;; URL: https://jblevins.org/projects/markdown-mode/
 
@@ -34,6 +34,7 @@
 ;;; Code:
 
 (require 'easymenu)
+(require 'compat)
 (require 'outline)
 (require 'thingatpt)
 (require 'cl-lib)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7445,6 +7445,12 @@ Standalone XHTML output is identified by an occurrence of
               stylesheet-path)
           "\"  />"))
 
+(defun markdown-escape-title (title)
+  "Escape a minimum set of characters in TITLE so they don't clash with html."
+  (string-replace ">" "&gt;"
+    (string-replace "<" "&lt;"
+      (string-replace "&" "&amp;" title))))
+
 (defun markdown-add-xhtml-header-and-footer (title)
   "Wrap XHTML header and footer with given TITLE around current buffer."
   (goto-char (point-min))
@@ -7453,7 +7459,7 @@ Standalone XHTML output is identified by an occurrence of
           "\t\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n\n"
           "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n\n"
           "<head>\n<title>")
-  (insert title)
+  (insert (markdown-escape-title title))
   (insert "</title>\n")
   (unless (= (length markdown-content-type) 0)
     (insert

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -7324,6 +7324,14 @@ Detail: https://github.com/jrblevin/markdown-mode/issues/747"
       (should (string= (buffer-substring-no-properties (point-min) (point-max))
                        "| -c | some text |\n|    |           |\n")))))
 
+(ert-deftest test-markdown-table/ensure-valid-html-title ()
+  "Test `markdown-table-aligh' for the line which starts with dash.
+Detail: https://github.com/jrblevin/markdown-mode/issues/747"
+  (markdown-test-string "simple"
+    (markdown-add-xhtml-header-and-footer "test<&>")
+    (goto-char (point-min))
+    (should (search-forward "test&lt;&amp;&gt;"))))
+
 (provide 'markdown-test)
 
 ;;; markdown-test.el ends here


### PR DESCRIPTION
Fixes cfclrk/markdown-xwidget#9

<!-- Provide a general summary of your changes in the Title above -->

Without this, a user (say, cfclrk's markdown-widget) could  provide a title of "README.md<tmp>" as it did when I discovered this bug.  That made the exported HTML un-usable.

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
