### PR TITLE
Don't treat backslashes as escapes inside literal blocks

### DIFF
--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2144,6 +2144,22 @@ See GH-245."
     (should (invisible-p (point)))
     (should-not (invisible-p (1+ (point))))))
 
+(ert-deftest test-markdown-markup-hiding/code-2 ()
+  "Test hiding markup for inline code with backslashes."
+  (markdown-test-file "inline.text"
+    (goto-char 460)
+    (should (looking-at "`C-h C-\\\\`"))
+    (markdown-test-range-has-property (point) (point) 'invisible 'markdown-markup)
+    (should-not (invisible-p (point)))
+    (should-not (invisible-p (+ 1 (point))))
+    (should-not (invisible-p (+ 7 (point))))
+    (should-not (invisible-p (+ 8 (point))))
+    (markdown-toggle-markup-hiding t)
+    (should (invisible-p (point)))
+    (should-not (invisible-p (+ 1 (point))))
+    (should-not (invisible-p (+ 7 (point))))
+    (should (invisible-p (+ 8 (point))))))
+
 (ert-deftest test-markdown-markup-hiding/kbd-1 ()
   "Test hiding markup for <kbd> tags."
   (markdown-test-string "<kbd>C-c C-x C-m</kbd>"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Backslashes get fontified as markup characters in too many situations. In particular, a backslash inside a literal block (e.g. code, math) should just be a literal backslash, not the introducer of an escape sequence.

It might be worthwhile to add some further regression tests here, but the one I did add fails without the fix, and passes with it.

## Related Issue

See #766.

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
