### PR TITLE
Don't allow space between label and text in reference link

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,8 @@
 *Under development*
 
 *   **Breaking changes:**
-    -   GNU Emacs 26.1 or later is required.
+    - GNU Emacs 26.1 or later is required.
+    - Don't allow space between label and text in reference link same as CommonMark [GH-774][]
 
 *   New Features:
     - Introduce `markdown-fontify-whole-heading-line` variable for highlighting
@@ -50,6 +51,7 @@
   [gh-766]: https://github.com/jrblevin/markdown-mode/issues/766
   [gh-768]: https://github.com/jrblevin/markdown-mode/pull/768
   [gh-771]: https://github.com/jrblevin/markdown-mode/issues/771
+  [gh-774]: https://github.com/jrblevin/markdown-mode/issues/774
 
 
 # Markdown Mode 2.5

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -704,7 +704,7 @@ Group 7 matches the title (optional).
 Group 8 matches the closing parenthesis.")
 
 (defconst markdown-regex-link-reference
-  "\\(?1:!\\)?\\(?2:\\[\\)\\(?3:[^]^][^]]*\\|\\)\\(?4:\\]\\)[ ]?\\(?5:\\[\\)\\(?6:[^]]*?\\)\\(?7:\\]\\)"
+  "\\(?1:!\\)?\\(?2:\\[\\)\\(?3:[^]^][^]]*\\|\\)\\(?4:\\]\\)\\(?5:\\[\\)\\(?6:[^]]*?\\)\\(?7:\\]\\)"
   "Regular expression for a reference link [text][id].
 Group 1 matches the leading exclamation point (optional).
 Group 2 matches the opening square bracket for the link text.

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5407,6 +5407,11 @@ http://example.com \"title\"  )
     (goto-char 13)
     (should (markdown-link-p))))
 
+(ert-deftest test-markdown-link/link-p-2 ()
+  "Don't allow space between label and text in reference link."
+  (markdown-test-string "[one] [two]"
+    (should-not (markdown-link-p))))
+
 ;;; Wiki link tests:
 
 (ert-deftest test-markdown-wiki-link/file-local-variables ()


### PR DESCRIPTION
This is same as CommonMark specification.

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#774 

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
