### PR TITLE
Require a space before the closing sequence of an atx heade

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 *   **Breaking changes:**
     - GNU Emacs 26.1 or later is required.
     - Don't allow space between label and text in reference link same as CommonMark [GH-774][]
+    - Whitespace is required before the closing sequence of an atx header. [GH-778][]
 
 *   New Features:
     - Introduce `markdown-fontify-whole-heading-line` variable for highlighting

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -732,7 +732,7 @@ Group 2 matches only the label, without the surrounding markup.
 Group 3 matches the closing square bracket.")
 
 (defconst markdown-regex-header
-  "^\\(?:\\(?1:[^\r\n\t -].*\\)\n\\(?:\\(?2:=+\\)\\|\\(?3:-+\\)\\)\\|\\(?4:#+[ \t]+\\)\\(?5:.*?\\)\\(?6:[ \t]*#*\\)\\)$"
+  "^\\(?:\\(?1:[^\r\n\t -].*\\)\n\\(?:\\(?2:=+\\)\\|\\(?3:-+\\)\\)\\|\\(?4:#+[ \t]+\\)\\(?5:.*?\\)\\(?6:[ \t]+#+\\)?\\)$"
   "Regexp identifying Markdown headings.
 Group 1 matches the text of a setext heading.
 Group 2 matches the underline of a level-1 setext heading.

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3013,6 +3013,16 @@ puts markdown.to_html
       (markdown-test-range-has-face 70 72 'font-lock-builtin-face) ; puts
       (markdown-test-range-has-face 92 94 'markdown-markup-face)))) ; ```
 
+(ert-deftest test-markdown-font-lock/atx-headers ()
+  "Test font-lock for atx headers"
+  (markdown-test-string "## abc  "
+    (markdown-test-range-has-face 1 3 'markdown-header-delimiter-face)
+    (markdown-test-range-has-face 4 8 'markdown-header-face-2))
+  (markdown-test-string "## abc ##"
+    (markdown-test-range-has-face 1 3 'markdown-header-delimiter-face)
+    (markdown-test-range-has-face 4 6 'markdown-header-face-2)
+    (markdown-test-range-has-face 7 9 'markdown-header-delimiter-face)))
+
 (ert-deftest test-markdown-font-lock/atx-no-spaces ()
   "Test font-lock for atx headers with no spaces."
   (markdown-test-string "##abc##"
@@ -3020,7 +3030,10 @@ puts markdown.to_html
   (markdown-test-string "##"
     (markdown-test-range-has-face 1 2 nil))
   (markdown-test-string "###"
-    (markdown-test-range-has-face 1 3 nil)))
+    (markdown-test-range-has-face 1 3 nil))
+  (markdown-test-string "## abc##"
+    (markdown-test-range-has-face 1 3 'markdown-header-delimiter-face)
+    (markdown-test-range-has-face 4 8 'markdown-header-face-2)))
 
 (ert-deftest test-markdown-font-lock/atx-whole-line ()
   "Test font-lock for atx headers with whole line flag."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Whitespace is required before the closing sequence of an atx header.
https://spec.commonmark.org/0.30/#example-75

## Related Issue
https://github.com/jrblevin/markdown-mode/issues/778

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
