### PR TITLE
Fix markdown-enter-key doesn't delete empty checkbox list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@
     - HTML-escape title in `markdown-add-xhtml-header-and-footer` [markdown-xwidget-issue-9](https://github.com/cfclrk/markdown-xwidget/issues/9)
     - Fix wrong inline link parsing that has link title[GH-762][]
     - Don't treat backslashes as escapes inside literal blocks[GH-766][] [GH-768][]
+    - Fix `markdown-enter-key` doesn't delete empty checkbox list[GH-786]
 
   [gh-377]: https://github.com/jrblevin/markdown-mode/issues/377
   [gh-572]: https://github.com/jrblevin/markdown-mode/issues/572
@@ -55,6 +56,7 @@
   [gh-773]: https://github.com/jrblevin/markdown-mode/issues/773
   [gh-774]: https://github.com/jrblevin/markdown-mode/issues/774
   [gh-778]: https://github.com/jrblevin/markdown-mode/issues/778
+  [gh-786]: https://github.com/jrblevin/markdown-mode/pull/786
 
 # Markdown Mode 2.5
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5066,9 +5066,10 @@ list simply adds a blank line)."
                (setq bounds (markdown-cur-list-item-bounds)))
           (let ((beg (cl-first bounds))
                 (end (cl-second bounds))
-                (length (cl-fourth bounds)))
+                (nonlist-indent (cl-fourth bounds))
+                (checkbox (cl-sixth bounds)))
             ;; Point is in a list item
-            (if (= (- end beg) length)
+            (if (= (- end beg) (+ nonlist-indent (length checkbox)))
                 ;; Delete blank list
                 (progn
                   (delete-region beg end)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2054,6 +2054,18 @@ Should not cause an infinite loop."
       (should (string-equal (buffer-string) "* foo\n* bar\n  * baz\n\n"))
       (should (eq (point) 22)))))
 
+(ert-deftest test-markdown-indentation/indent-checkbox-list ()
+  "Test `markdown-indent-line' with a list item with checkbox."
+  (let ((markdown-indent-on-enter 'indent-and-new-item))
+    (markdown-test-string "  * [x] item 1"
+      (end-of-line)
+      (call-interactively #'markdown-enter-key)
+      (should (string-equal (buffer-string) "  * [x] item 1\n  * [ ] "))
+      (should (eq (point) 24))
+      (call-interactively #'markdown-enter-key)
+      (should (string-equal (buffer-string) "  * [x] item 1\n\n"))
+      (should (eq (point) 17)))))
+
 (ert-deftest test-markdown-indentation/indent-pre ()
   "Test `markdown-indent-line' with a pre block."
   (markdown-test-string


### PR DESCRIPTION
## Description
I have updated `markdown-enter-key` to delete empty checkboxes.
I think this action is better, similar to how GitHub's issue editor handles it.

## Issue
### Expected Behavior:
When pressing enter on an empty checkbox list, the list should be deleted.
 
### Actual Behavior:
A new list with a checkbox is added to the next line.

### Steps to Reproduce
When I pressed enter on an empty checkbox item (with the cursor located after the checkbox),
```
- [x] 
```
a new list item was added, resulting in the following:

```
- [x] 
- [ ]
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).