### PR TITLE
Push mark before jumping to footnote

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4665,6 +4665,7 @@ element. More details here https://developer.mozilla.org/en-US/docs/Web/HTML/Ele
   (interactive)
   (let ((fn (markdown-footnote-counter-inc)))
     (insert (format "[^%d]" fn))
+    (push-mark (point) t)
     (markdown-footnote-text-find-new-location)
     (markdown-ensure-blank-line-before)
     (unless (markdown-cur-line-blank-p)


### PR DESCRIPTION
## Description

When inserting a (small) footnote, it is often very convenient to jump back to the main text with C-u C-SPC instead of using `markdown-footnote-return`. However, this can only be done if `markdown-insert-footnote` pushes to the mark ring before jumping, so do that.

## Type of Change

- [n/a] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [n/a] New feature (non-breaking change which adds functionality)
- [n/a] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [n/a] I have updated the documentation in the **README.md** file if necessary.
- [n/a] I have added an entry to **CHANGES.md**.

  Not significant enough to warrant this, I think.

- [n/a] I have added tests to cover my changes.

  Not significant enough to warrant this, I think.

- [x] All new and existing tests passed (using `make test`).