### PR TITLE
Set pre attribute the end of the last line for indented block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
     - Improve `markdown-insert-table` prompt message [GH-771][]
     - Consider `major-mode-remap-alist` to determine major-mode for code blocks [GH-787][]
     - Set marker after footnote reference [GH-793][]
+    - Improve putting text attribute for indented blocks [GH-794][]
 
 *   Bug fixes:
     - Don't override table faces by link faces [GH-716][]
@@ -61,6 +62,7 @@
   [gh-786]: https://github.com/jrblevin/markdown-mode/pull/786
   [gh-787]: https://github.com/jrblevin/markdown-mode/issues/787
   [gh-793]: https://github.com/jrblevin/markdown-mode/pull/793
+  [gh-794]: https://github.com/jrblevin/markdown-mode/issues/794
 
 # Markdown Mode 2.5
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1317,6 +1317,7 @@ giving the bounds of the current and parent list items."
                           (not (eobp)))
                 (forward-line))
               (skip-syntax-backward "-")
+              (forward-line)
               (setq close (point)))
              ;; If current line has a list marker, update levels, move to end of block
              ((looking-at markdown-regex-list)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -3826,8 +3826,8 @@ returns nil."
     (should (equal (markdown-syntax-propertize-extend-region 93 157)
                    nil))
     (should (equal (markdown-syntax-propertize-extend-region 496 502)
-                   (cons 486 510)))
-    (should (equal (markdown-syntax-propertize-extend-region 486 510)
+                   (cons 486 511)))
+    (should (equal (markdown-syntax-propertize-extend-region 486 511)
                    nil))
     ;; Region that begins and ends with \n\n should not be extended
     (should (equal (markdown-syntax-propertize-extend-region 157 355)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

### Before

![before](https://github.com/jrblevin/markdown-mode/assets/554281/cccb7004-02ba-4d01-911c-579a3f43bc80)

### With this patch

![after](https://github.com/jrblevin/markdown-mode/assets/554281/aac52b47-cca3-48c0-98cd-8f295a70273c)

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#794 (CC: @phuhl )

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Improvement (non-breaking change which improves an existing feature)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
