### PR TITLE
Add extensible link-opening system

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,19 @@
 
 *Under development*
 
+*   New Features:
+    - Variable `markdown-follow-link-functions` extends
+      `markdown-follow-link-at-point` similarly to Org's
+      `org-open-at-point-functions`, allowing other libraries to
+      handle links specially. [GH-780][]
+
 *   Bug fixes:
     - Don't highlight superscript/subscript in math inline/block [GH-802][]
 
 *   Improvements:
     - Apply url-unescape against URL in an inline link [GH-805][]
 
+  [gh-780]: https://github.com/jrblevin/markdown-mode/issues/780
   [gh-802]: https://github.com/jrblevin/markdown-mode/issues/802
   [gh-805]: https://github.com/jrblevin/markdown-mode/issues/805
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8337,7 +8337,7 @@ See `markdown-follow-link-at-point' and
 `markdown-follow-wiki-link-at-point'."
   (interactive "P")
   (cond ((markdown-link-p)
-         (markdown--browse-url (markdown-link-url)))
+         (markdown-follow-link-at-point))
         ((markdown-wiki-link-p)
          (markdown-follow-wiki-link-at-point arg))
         (t

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7930,12 +7930,11 @@ If the link is a complete URL, open in browser with `browse-url'.
 Otherwise, open with `find-file' after stripping anchor and/or query string.
 Translate filenames using `markdown-filename-translate-function'."
   (interactive (list last-command-event))
-  (save-excursion
-    (if event (posn-set-point (event-start event)))
-    (if (markdown-link-p)
-        (or (run-hook-with-args-until-success 'markdown-follow-link-functions (markdown-link-url))
-            (markdown--browse-url (markdown-link-url)))
-      (user-error "Point is not at a Markdown link or URL"))))
+  (if event (posn-set-point (event-start event)))
+  (if (markdown-link-p)
+      (or (run-hook-with-args-until-success 'markdown-follow-link-functions (markdown-link-url))
+          (markdown--browse-url (markdown-link-url)))
+    (user-error "Point is not at a Markdown link or URL")))
 
 (defun markdown-fontify-inline-links (last)
   "Add text properties to next inline link from point to LAST."

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -73,6 +73,13 @@
 (defvar markdown-gfm-language-history nil
   "History list of languages used in the current buffer in GFM code blocks.")
 
+(defvar markdown-follow-link-functions nil
+  "Functions used to follow a link.
+Each function is called with one argument, the link's URL. It
+should return non-nil if it followed the link, or nil if not.
+Functions are called in order until one of them returns non-nil;
+otherwise the default link-following function is used.")
+
 
 ;;; Customizable Variables ====================================================
 
@@ -7926,7 +7933,8 @@ Translate filenames using `markdown-filename-translate-function'."
   (save-excursion
     (if event (posn-set-point (event-start event)))
     (if (markdown-link-p)
-        (markdown--browse-url (markdown-link-url))
+        (or (run-hook-with-args-until-success 'markdown-follow-link-functions (markdown-link-url))
+            (markdown--browse-url (markdown-link-url)))
       (user-error "Point is not at a Markdown link or URL"))))
 
 (defun markdown-fontify-inline-links (last)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -51,17 +51,15 @@
   "Run BODY in a temporary buffer containing STRING in MODE."
   (declare (indent 2))
   `(let ((win (selected-window)))
-     (unwind-protect
-         (with-temp-buffer
-           (set-window-buffer win (current-buffer) t)
-           (erase-buffer)
-           (insert ,string)
-           (funcall ,mode)
-           (setq-default indent-tabs-mode nil)
-           (goto-char (point-min))
-           (font-lock-ensure)
-           (prog1 ,@body (kill-buffer)))
-       (ignore))))
+     (with-temp-buffer
+       (set-window-buffer win (current-buffer) t)
+       (erase-buffer)
+       (insert ,string)
+       (funcall ,mode)
+       (setq-default indent-tabs-mode nil)
+       (goto-char (point-min))
+       (font-lock-ensure)
+       ,@body)))
 
 (defmacro markdown-test-file-mode (mode file &rest body)
   "Open FILE from `markdown-test-dir' in MODE and execute BODY."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Similar to Org mode's `org-open-at-point-functions`, this provides a new hook, `markdown-follow-link-functions`, which may be a list of functions which are called with a link's URL and offered the chance to handle the link-following action.  

This allows other libraries to affect how `markdown-mode` follows links.  For example, this allows [hyperdrive.el](https://git.sr.ht/~ushin/hyperdrive.el) to follow relative links between files in a hyperdrive (i.e. links that are not full URLs but just paths, like `../sibling-directory/file.md`).

<!-- More detailed description of the changes if needed. -->

Among the changes in this PR are an improvement to one of the test macros, and a fix in one of the link-following functions.  All the tests still pass as expected.

## Related Issue

This implements the feature mentioned in https://github.com/jrblevin/markdown-mode/issues/780.
<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.  (It doesn't seem very practical to add automated tests, but the code is very simple, and I have conducted extensive manual testing with `hyperdrive-mode`.)
- [x] All new and existing tests passed (using `make test`).

Thanks for your work on `markdown-mode`.