### PR TITLE
Add `markdown-beginning/end-of-line` functions and `markdown-special-ctrl-a/e` variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
       `org-open-at-point-functions`, allowing other libraries to
       handle links specially. [GH-780][]
     - Support media handler for images and drag and drop images [GH-804][]
+    - Add functions to move to the beginning and end of lines
+      (`markdown-beginning-of-line` and `markdown-end-of-line`), and the
+      variable `markdown-special-ctrl-a/e`, like Org mode.
 
 *   Bug fixes:
     - Don't highlight superscript/subscript in math inline/block [GH-802][]

--- a/README.md
+++ b/README.md
@@ -935,6 +935,15 @@ provides an interface to all of the possible customizations:
   * `markdown-fontify-whole-heading-line` - font lock for highlighting
      the whole line for headings.(default: `nil`)
 
+  * `markdown-special-ctrl-a/e` - set to non-nil to behave specially in
+    headlines and items. When `t`, `C-a` will bring back the cursor to the
+    beginning of the headline text. In an item, this will be the position after
+    bullet and check-box, if any. `C-e` will jump to the end of the headline,
+    ignoring the presence of closing tags in the headline. When set to the
+    symbol `reversed`, the first `C-a` or `C-e` works normally, going to the
+    true line boundary first. Only a directly following, identical keypress will
+    bring the cursor to the special positions (default: `nil`).
+
 Additionally, the faces used for syntax highlighting can be modified to
 your liking by issuing <kbd>M-x customize-group RET markdown-faces</kbd>
 or by using the "Markdown Faces" link at the bottom of the mode

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -6534,7 +6534,7 @@ With argument N not nil or 1, move forward N - 1 lines first."
                    (`(,C-a . ,_) C-a) (_ markdown-special-ctrl-a/e)))
         deactivate-mark)
     ;; First move to a visible line.
-    (if (bound-and-true-p visual-line-mode)
+    (if visual-line-mode
         (beginning-of-visual-line n)
       (move-beginning-of-line n)
       ;; `move-beginning-of-line' may leave point after invisible
@@ -6549,7 +6549,7 @@ With argument N not nil or 1, move forward N - 1 lines first."
      ;; `beginning-of-visual-line' left point before logical beginning
      ;; of line: point is at the beginning of a visual line.  Bail
      ;; out.
-     ((and (bound-and-true-p visual-line-mode) (not (bolp))))
+     ((and visual-line-mode (not (bolp))))
      ((looking-at markdown-regex-header-atx)
       ;; At a header, special position is before the title.
       (let ((refpos (match-beginning 2))
@@ -6594,7 +6594,7 @@ With argument N not nil or 1, move forward N - 1 lines first."
                    (`(,_ . ,C-e) C-e) (_ markdown-special-ctrl-a/e)))
         deactivate-mark)
     ;; First move to a visible line.
-    (if (bound-and-true-p visual-line-mode)
+    (if visual-line-mode
         (beginning-of-visual-line n)
       (move-beginning-of-line n))
     (cond
@@ -6603,7 +6603,7 @@ With argument N not nil or 1, move forward N - 1 lines first."
         (forward-line 0)
         (and (looking-at markdown-regex-header-atx) (match-end 3)))
       (let ((refpos (match-end 2))
-            (visual-end (and (bound-and-true-p visual-line-mode)
+            (visual-end (and visual-line-mode
                              (save-excursion
                                (end-of-visual-line)
                                (point)))))
@@ -6629,7 +6629,7 @@ With argument N not nil or 1, move forward N - 1 lines first."
         (when (and markdown-hide-markup
                    (equal (get-char-property (point) 'display) ""))
           (setq disable-point-adjustment t))))
-     ((bound-and-true-p visual-line-mode)
+     (visual-line-mode
       (let ((bol (line-beginning-position)))
         (end-of-visual-line)
         ;; If `end-of-visual-line' gets us past the ellipsis at the

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -659,6 +659,44 @@ markdown-header-face-* faces."
   :safe 'booleanp
   :package-version '(markdown-mode . "2.5"))
 
+(defcustom markdown-special-ctrl-a/e nil
+  "Non-nil means `C-a' and `C-e' behave specially in headlines and items.
+
+When t, `C-a' will bring back the cursor to the beginning of the
+headline text. In an item, this will be the position after bullet
+and check-box, if any. When the cursor is already at that
+position, another `C-a' will bring it to the beginning of the
+line.
+
+`C-e' will jump to the end of the headline, ignoring the presence
+of closing tags in the headline. A second `C-e' will then jump to
+the true end of the line, after closing tags. This also means
+that, when this variable is non-nil, `C-e' also will never jump
+beyond the end of the heading of a folded section, i.e. not after
+the ellipses.
+
+When set to the symbol `reversed', the first `C-a' or `C-e' works
+normally, going to the true line boundary first.  Only a directly
+following, identical keypress will bring the cursor to the
+special positions.
+
+This may also be a cons cell where the behavior for `C-a' and
+`C-e' is set separately."
+  :group 'markdown
+  :type '(choice
+	  (const :tag "off" nil)
+	  (const :tag "on: after hashes/bullet and before closing tags first" t)
+	  (const :tag "reversed: true line boundary first" reversed)
+	  (cons :tag "Set C-a and C-e separately"
+		(choice :tag "Special C-a"
+			(const :tag "off" nil)
+			(const :tag "on: after hashes/bullet first" t)
+			(const :tag "reversed: before hashes/bullet first" reversed))
+		(choice :tag "Special C-e"
+			(const :tag "off" nil)
+			(const :tag "on: before closing tags first" t)
+			(const :tag "reversed: after closing tags first" reversed))))
+  :package-version '(markdown-mode . "2.7"))
 
 ;;; Markdown-Specific `rx' Macro ==============================================
 
@@ -5531,6 +5569,9 @@ Assumes match data is available for `markdown-regex-italic'."
     (define-key map (kbd "C-x n s") 'markdown-narrow-to-subtree)
     (define-key map (kbd "M-RET") 'markdown-insert-list-item)
     (define-key map (kbd "C-c C-j") 'markdown-insert-list-item)
+    ;; Lines
+    (define-key map [remap move-beginning-of-line] 'markdown-beginning-of-line)
+    (define-key map [remap move-end-of-line] 'markdown-end-of-line)
     ;; Paragraphs (Markdown context aware)
     (define-key map [remap backward-paragraph] 'markdown-backward-paragraph)
     (define-key map [remap forward-paragraph] 'markdown-forward-paragraph)
@@ -6473,6 +6514,122 @@ a list."
 
 
 ;;; Movement ==================================================================
+
+;; This function was originally derived from `org-beginning-of-line' from org.el.
+(defun markdown-beginning-of-line (&optional n)
+  "Go to the beginning of the current visible line.
+
+If this is a headline, and `markdown-special-ctrl-a/e' is not nil
+or symbol `reversed', on the first attempt move to where the
+headline text hashes, and only move to beginning of line when the
+cursor is already before the hashes of the text of the headline.
+
+If `markdown-special-ctrl-a/e' is symbol `reversed' then go to
+the hashes of the text on the second attempt.
+
+With argument N not nil or 1, move forward N - 1 lines first."
+  (interactive "^p")
+  (let ((origin (point))
+        (special (pcase markdown-special-ctrl-a/e
+                   (`(,C-a . ,_) C-a) (_ markdown-special-ctrl-a/e)))
+        deactivate-mark)
+    ;; First move to a visible line.
+    (if (bound-and-true-p visual-line-mode)
+        (beginning-of-visual-line n)
+      (move-beginning-of-line n)
+      ;; `move-beginning-of-line' may leave point after invisible
+      ;; characters if line starts with such of these (e.g., with
+      ;; a link at column 0).  Really move to the beginning of the
+      ;; current visible line.
+      (forward-line 0))
+    (cond
+     ;; No special behavior.  Point is already at the beginning of
+     ;; a line, logical or visual.
+     ((not special))
+     ;; `beginning-of-visual-line' left point before logical beginning
+     ;; of line: point is at the beginning of a visual line.  Bail
+     ;; out.
+     ((and (bound-and-true-p visual-line-mode) (not (bolp))))
+     ((looking-at markdown-regex-header-atx)
+      ;; At a header, special position is before the title.
+      (let ((refpos (match-beginning 2))
+            (bol (point)))
+        (if (eq special 'reversed)
+            (when (and (= origin bol) (eq last-command this-command))
+              (goto-char refpos))
+          (when (or (> origin refpos) (<= origin bol))
+            (goto-char refpos)))))
+     ((looking-at markdown-regex-list)
+      ;; At a list item, special position is after the list marker or checkbox.
+      (let ((refpos (or (match-end 4) (match-end 3))))
+        (if (eq special 'reversed)
+            (when (and (= (point) origin) (eq last-command this-command))
+              (goto-char refpos))
+          (when (or (> origin refpos) (<= origin (line-beginning-position)))
+          (goto-char refpos)))))
+     ;; No special case, already at beginning of line.
+     (t nil))))
+
+;; This function was originally derived from `org-end-of-line' from org.el.
+(defun markdown-end-of-line (&optional n)
+  "Go to the end of the line, but before ellipsis, if any.
+
+If this is a headline, and `markdown-special-ctrl-a/e' is not nil
+or symbol `reversed', ignore closing tags on the first attempt,
+and only move to after the closing tags when the cursor is
+already beyond the end of the headline.
+
+If `markdown-special-ctrl-a/e' is symbol `reversed' then ignore
+closing tags on the second attempt.
+
+With argument N not nil or 1, move forward N - 1 lines first."
+  (interactive "^p")
+  (let ((origin (point))
+        (special (pcase markdown-special-ctrl-a/e
+                   (`(,_ . ,C-e) C-e) (_ markdown-special-ctrl-a/e)))
+        deactivate-mark)
+    ;; First move to a visible line.
+    (if (bound-and-true-p visual-line-mode)
+        (beginning-of-visual-line n)
+      (move-beginning-of-line n))
+    (cond
+     ;; At a headline, with closing tags.
+     ((and special
+           (save-excursion
+             (forward-line 0)
+             (and
+              (looking-at markdown-regex-header-atx)
+              (match-end 3))))
+      (let ((refpos (match-end 2))
+            (visual-end (and (bound-and-true-p visual-line-mode)
+                             (save-excursion
+                               (end-of-visual-line)
+                               (point)))))
+        ;; If `end-of-visual-line' brings us before end of line or even closing
+        ;; tags, i.e., the headline spans over multiple visual lines, move
+        ;; there.
+        (cond ((and visual-end
+                    (< visual-end refpos)
+                    (<= origin visual-end))
+               (goto-char visual-end))
+              ((eq special 'reversed)
+               (if (and (= origin (line-end-position))
+                        (eq this-command last-command))
+                   (goto-char refpos)
+                 (end-of-line)))
+              (t
+               (if (or (< origin refpos) (>= origin (line-end-position)))
+                   (goto-char refpos)
+                 (end-of-line))))))
+     ((bound-and-true-p visual-line-mode)
+      (let ((bol (line-beginning-position)))
+        (end-of-visual-line)
+        ;; If `end-of-visual-line' gets us past the ellipsis at the
+        ;; end of a line, backtrack and use `end-of-line' instead.
+        (when (/= bol (line-beginning-position))
+          (goto-char bol)
+          (end-of-line))))
+     (t (end-of-line)))))
 
 (defun markdown-beginning-of-defun (&optional arg)
   "`beginning-of-defun-function' for Markdown.
@@ -10042,7 +10199,18 @@ rows and columns and the column alignment."
 
   ;; add live preview export hook
   (add-hook 'after-save-hook #'markdown-live-preview-if-markdown t t)
-  (add-hook 'kill-buffer-hook #'markdown-live-preview-remove-on-kill t t))
+  (add-hook 'kill-buffer-hook #'markdown-live-preview-remove-on-kill t t)
+
+  ;; Add a custom keymap for `visual-line-mode' so that activating
+  ;; this minor mode does not override markdown-mode's keybindings.
+  ;; FIXME: Probably `visual-line-mode' should take care of this.
+  (let ((oldmap (cdr (assoc 'visual-line-mode minor-mode-map-alist)))
+        (newmap (make-sparse-keymap)))
+    (set-keymap-parent newmap oldmap)
+    (define-key newmap [remap move-beginning-of-line] nil)
+    (define-key newmap [remap move-end-of-line] nil)
+    (make-local-variable 'minor-mode-overriding-map-alist)
+    (push `(visual-line-mode . ,newmap) minor-mode-overriding-map-alist)))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Add functions to move to the beginning and end of lines (`markdown-beginning-of-line` and `markdown-end-of-line`), and the variable `markdown-special-ctrl-a/e`, like Org mode.

I implemented it based on [this version](https://git.savannah.gnu.org/cgit/emacs/org-mode.git/tree/lisp/org.el?id=4d72f3a0d2b018b5d3384085ddc410caf7c884d9#n20305) of Org mode.


## Related Issue
https://github.com/jrblevin/markdown-mode/issues/811

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
