### PR TITLE
Hide trailing whitespace when hiding markup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
     - Add functions to move to the beginning and end of lines
       (`markdown-beginning-of-line` and `markdown-end-of-line`), and the
       variable `markdown-special-ctrl-a/e`, like Org mode.
+    - Trailing whitespace characters for line breaks are hidden when using
+      `markdown-hide-markup`
 
 *   Bug fixes:
     - Don't highlight superscript/subscript in math inline/block [GH-802][]

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1855,6 +1855,10 @@ START and END delimit region to propertize."
   '(face markdown-markup-face invisible markdown-markup)
   "List of properties and values to apply to markup.")
 
+(defconst markdown-line-break-properties
+  '(face markdown-line-break-face invisible markdown-markup)
+  "List of properties and values to apply to line break markup.")
+
 (defconst markdown-language-keyword-properties
   '(face markdown-language-keyword-face invisible markdown-markup)
   "List of properties and values to apply to code block language names.")
@@ -2298,7 +2302,7 @@ Depending on your font, some reasonable choices are:
     (markdown--match-highlighting . ((3 markdown-markup-properties)
                                      (4 'markdown-highlighting-face)
                                      (5 markdown-markup-properties)))
-    (,markdown-regex-line-break . (1 'markdown-line-break-face prepend))
+    (,markdown-regex-line-break . (1 markdown-line-break-properties prepend))
     (markdown-match-escape . ((1 markdown-markup-properties prepend)))
     (markdown-fontify-sub-superscripts)
     (markdown-match-inline-attributes . ((0 markdown-markup-properties prepend)))

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2257,6 +2257,18 @@ See GH-245."
     (should (invisible-p (point)))
     (should-not (invisible-p (1+ (point))))))
 
+(ert-deftest test-markdown-markup-hiding/line-break ()
+  "Test hiding markup for line break markup."
+  (markdown-test-string "hello  \nworld"
+    (markdown-test-range-has-property (+ 5 (point)) (+ 6 (point)) 'invisible 'markdown-markup)
+    (should-not (invisible-p (point))) ;; part of "hello"
+    (should-not (invisible-p (+ 5 (point)))) ;; part of line break
+    (should-not (invisible-p (+ 7 (point)))) ;; part of "world"
+    (markdown-toggle-markup-hiding t)
+    (should-not (invisible-p (point))) ;; part of "hello"
+    (should (invisible-p (+ 5 (point)))) ;; part of line break
+    (should-not (invisible-p (+ 7 (point)))))) ;; inside "world"
+
 ;;; Markup hiding url tests:
 
 (ert-deftest test-markdown-url-hiding/eldoc ()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

When hiding markup, e.g. via `markdown-view-mode`, the trailing whitespace markup for line breaks doesn't get hidden. This patch changes it so that the whitespace *is* hidden when hiding other markup. In practice, this just makes the `"  "` invisible and nothing else; then, we let the newline do its usual thing.

(In the future, I could imagine `markdown-view-mode` handling soft newlines differently, so that something like `foo\nbar` is displayed as `foo bar`. Then, we'd probably want to do something special to mark the newline in `  \n` as a *hard* newline.)

## Related Issue

See <https://debbugs.gnu.org/cgi/bugreport.cgi?bug=69647>

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).