### PR TITLE
Inhibit math support message when calling `markdown-mode`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 
 *   Improvements:
     - Apply url-unescape against URL in an inline link [GH-805][]
+    - Inhibit math support message when calling `markdown-mode`
 
   [gh-780]: https://github.com/jrblevin/markdown-mode/issues/780
   [gh-802]: https://github.com/jrblevin/markdown-mode/issues/802

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -10151,7 +10151,9 @@ rows and columns and the column alignment."
   ;; Wiki links
   (markdown-setup-wiki-link-hooks)
   ;; Math mode
-  (when markdown-enable-math (markdown-toggle-math t))
+  (when markdown-enable-math
+    (font-lock-add-keywords
+     'markdown-mode markdown-mode-font-lock-keywords-math))
   ;; Add a buffer-local hook to reload after file-local variables are read
   (add-hook 'hack-local-variables-hook #'markdown-handle-local-variables nil t)
   ;; For imenu support


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

## Description
The message output by `markdown-toggle-math` interferes with the echo area usage of `eglot` and `lsp-mode`. See
- https://github.com/joaotavora/eglot/discussions/1394
- https://github.com/emacs-lsp/lsp-mode/issues/802

IMHO it also feels more idiomatic to reserve `markdown-toggle-math` for interactive calls.

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
