### PR TITLE
Never hide backslash escapes in fontified code blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
     - Don't highlight superscript/subscript in math inline/block [GH-802][]
     - Fix table alignment when a column has a seperator in code block [GH-817][]
     - Fix the regexp in the download languages script [GH-827][]
+    - Don't hide backslashes in code blocks when using `markdown-hide-markup`
+      and `markdown-fontify-code-blocks-natively` together [GH-766][]
 
 *   Improvements:
     - Apply url-unescape against URL in an inline link [GH-805][]

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1141,7 +1141,8 @@ Group 4 matches the text inside the delimiters.")
   "Property list of all Markdown syntactic properties.")
 
 (defvar markdown-literal-faces
-  '(markdown-inline-code-face
+  '(markdown-code-face
+    markdown-inline-code-face
     markdown-pre-face
     markdown-math-face
     markdown-url-face

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2243,9 +2243,25 @@ See GH-245."
       (markdown-test-range-has-property 83 93 'invisible 'markdown-markup)
       (should (invisible-p 83))
       (should (invisible-p 93))
-      (markdown-test-range-has-property 154 156 'invisible 'markdown-markup)
-      (should (invisible-p 154))
-      (should (invisible-p 156)))))
+      ;; The backslash in the Bash script should be visible.
+      (should-not (invisible-p 167))
+      (markdown-test-range-has-property 174 176 'invisible 'markdown-markup)
+      (should (invisible-p 174))
+      (should (invisible-p 176)))))
+
+(ert-deftest test-markdown-markup-hiding/fenced-code-blocks-fontified ()
+  "Test hiding markup for tilde fenced code blocks with fontification."
+  (let ((markdown-hide-markup t)
+        (markdown-fontify-code-blocks-natively t))
+    (markdown-test-file "outline-code.text"
+      (markdown-test-range-has-property 83 93 'invisible 'markdown-markup)
+      (should (invisible-p 83))
+      (should (invisible-p 93))
+      ;; The backslash in the Bash script should be visible.
+      (should-not (invisible-p 167))
+      (markdown-test-range-has-property 174 176 'invisible 'markdown-markup)
+      (should (invisible-p 174))
+      (should (invisible-p 176)))))
 
 (ert-deftest test-markdown-markup-hiding/escape ()
   "Test hiding markup for backslash escapes."
@@ -4838,7 +4854,7 @@ Detail: https://github.com/jrblevin/markdown-mode/issues/392"
   (markdown-test-file "outline-code.text"
     ;; Navigate forward at the same level
     (markdown-forward-same-level 1)
-    (should (eq (point) 159))
+    (should (eq (point) 179))
     (should (looking-at "^# Level one again"))))
 
 (ert-deftest test-markdown-outline/back-to-heading-over-code-block ()
@@ -4927,7 +4943,7 @@ Detail: https://github.com/jrblevin/markdown-mode/issues/392"
       (should (eq (point) 69))
       (should (looking-at "^## Level two"))
       (outline-next-visible-heading 1)
-      (should (eq (point) 159))
+      (should (eq (point) 179))
       (should (looking-at "^# Level one again")))))
 
 (ert-deftest test-markdown-outline/visibility-with-metadata ()

--- a/tests/outline-code.text
+++ b/tests/outline-code.text
@@ -10,6 +10,8 @@
 #!/bin/bash
 
 # In a code block, this shouldn't be a header
+
+echo -e "foo\nbar"
 ~~~
 
 # Level one again


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Previously, if hiding markup and using native fontification of code blocks, backslash escapes could get hidden inside code. To fix this, we just need to mark `markdown-code-face` as a literal face.

## Related Issue

#766 (see the end of the discussion).

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
