### PR TITLE
Get rid of some quadratic behavior

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,8 @@
     - Consider `major-mode-remap-alist` to determine major-mode for code blocks [GH-787][]
     - Set marker after footnote reference [GH-793][]
     - Improve putting text attribute for indented blocks [GH-794][]
+    - Some sources of pathological behavior of markdown-match-bold and markdown-match-italic
+      on large blocks have been mitigated
 
 *   Bug fixes:
     - Don't override table faces by link faces [GH-716][]


### PR DESCRIPTION
markdown-match-bold and markdown-match-italic both call markdown-inline-code-at-pos-p on each candidate match, which takes linear time in the distance
from the start of the block to the point being checked.

In a large block with many candidate matches inside inline blocks, this is slow because the function is called with each candidate, resulting in overall quadratic behavior, which this commit fixes by starting the code-at-pos scan after the last already-found match.

For example, the following benchmark code:

```
(with-temp-buffer
  (dotimes (_ 400)
    (insert "`my_test_string`\n"))
  (markdown-mode)
  (car (benchmark-run
           (font-lock-debug-fontify))))
```

takes about 10.5 seconds before this commit, and about 0.14 seconds after this commit.

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
(except `test-markdown-export/buffer-local-css-path` which was already failing)
