### PR TITLE
Remove square brackets in skip-chars-forward argument

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3828,12 +3828,12 @@ prefixed with an integer from 1 to the length of
         (when (and beg skip-space)
           (save-excursion
             (goto-char beg)
-            (skip-chars-forward "[ \t]")
+            (skip-chars-forward " \t")
             (setq beg (point))))
         (when (and end skip-space)
           (save-excursion
             (goto-char end)
-            (skip-chars-backward "[ \t]")
+            (skip-chars-backward " \t")
             (setq end (point))))
         (markdown-wrap-or-insert start-delim end-delim nil beg end))
     (if (markdown--face-p (point) (list face))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4910,7 +4910,7 @@ footnote text is found, NIL is returned."
   (save-excursion
     (goto-char (point-min))
     (when (re-search-forward (concat "^ \\{0,3\\}\\[" id "\\]:") nil t)
-      (skip-chars-forward "[ \t]")
+      (skip-chars-forward " \t")
       (point))))
 
 (defun markdown-footnote-marker-positions ()


### PR DESCRIPTION
## Description

The string passed to `skip-chars-forward` contains the characters to skip; these characters should not be enclosed in square brackets. This change removes these inappropriate square brackets, one instance of which was causing the function `markdown-footnote-find-text` to sometimes return an incorrect result, as documented in the issue below.

## Related Issue

Fixes #837.

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).