### PR TITLE
Fixes #848: Resolve `markdown-fontify-whole-heading-line` issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@
       `markdown-hide-markup`
 
 *   Bug fixes:
+    - Fixes an issue where, when `markdown-fontify-whole-heading-line` is
+      enabled, the leading `#` characters in headers are not fontified the same
+      as the heading.
     - Don't highlight superscript/subscript in math inline/block [GH-802][]
     - Fix table alignment when a column has a seperator in code block [GH-817][]
     - Fix the regexp in the download languages script [GH-827][]

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3563,8 +3563,10 @@ SEQ may be an atom or a sequence."
                (if markdown-fontify-whole-heading-line
                    (min (point-max) (1+ (match-end 0)))
                  (match-end 0))))
-          (add-text-properties
-           (match-beginning 4) (match-end 4) left-markup-props)
+          (if markdown-fontify-whole-heading-line
+              (add-text-properties (match-beginning 0) header-end heading-props)
+            (add-text-properties
+             (match-beginning 4) (match-end 4) left-markup-props))
 
           ;; If closing tag is present
           (if (match-end 6)


### PR DESCRIPTION
## Description

This pull request fixes a bug where, when `markdown-fontify-whole-heading-line` is enabled, the leading `#` characters in headers are not fontified the same as the heading

It makes `markdown-fontify-whole-heading-line` to apply fontification to the entire line for headings.

## Related Issue

Issue: https://github.com/jrblevin/markdown-mode/issues/848

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes. (minor change.)
- [x] All new and existing tests passed (using `make test`).
