### PR TITLE
Mark `markdown-css-paths` safe as a file local var

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
     - Show mode toggle message only if it is called interactively
     - Copy `markdown-css-paths` in the output buffer [GH-834][]
     - Change temporary buffer name according to the Emacs naming convention [GH-848][]
+    - Mark `markdown-css-paths` safe as file local variables [GH-834][]
 
   [gh-780]: https://github.com/jrblevin/markdown-mode/issues/780
   [gh-802]: https://github.com/jrblevin/markdown-mode/issues/802

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -370,6 +370,7 @@ Math support can be enabled, disabled, or toggled later using
 (defcustom markdown-css-paths nil
   "List of URLs of CSS files to link to in the output XHTML."
   :group 'markdown
+  :safe (apply-partially #'seq-every-p #'stringp)
   :type '(repeat (string :tag "CSS File Path")))
 
 (defcustom markdown-content-type "text/html"


### PR DESCRIPTION
## Description

Make it possible to set `markdown-css-paths` as a file local variable.

This fixes the "file local variable" part of #834.

## Related Issue

#834

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
  - I'm not sure if this makes sense to encode in a test.
    I'll look at it if you think it does though.
- [x] All new and existing tests passed (using `make test`).