### PR TITLE
Support relative paths in stylesheets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@
     - Copy `markdown-css-paths` in the output buffer [GH-834][]
     - Change temporary buffer name according to the Emacs naming convention [GH-848][]
     - Mark `markdown-css-paths` safe as file local variables [GH-834][]
+    - Resolve style sheets in `markdown-css-paths` relative to the Markdown file
+      [GH-855][]
 
   [gh-780]: https://github.com/jrblevin/markdown-mode/issues/780
   [gh-802]: https://github.com/jrblevin/markdown-mode/issues/802
@@ -40,6 +42,7 @@
   [gh-838]: https://github.com/jrblevin/markdown-mode/issues/838
   [gh-845]: https://github.com/jrblevin/markdown-mode/issues/845
   [gh-848]: https://github.com/jrblevin/markdown-mode/issues/848
+  [gh-855]: https://github.com/jrblevin/markdown-mode/issues/855
 
 # Markdown Mode 2.6
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7736,9 +7736,7 @@ Standalone XHTML output is identified by an occurrence of
 
 (defun markdown-stylesheet-link-string (stylesheet-path)
   (concat "<link rel=\"stylesheet\" type=\"text/css\" media=\"all\" href=\""
-          (or (and (string-prefix-p "~" stylesheet-path)
-                   (expand-file-name stylesheet-path))
-              stylesheet-path)
+          (expand-file-name stylesheet-path)
           "\"  />"))
 
 (defun markdown-escape-title (title)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -6184,15 +6184,29 @@ bar baz"
 
 (ert-deftest test-markdown-export/buffer-local-css-path ()
   "Test buffer local `markdown-css-paths'"
-  (let ((markdown-css-paths '("./global.css")))
+  (let ((markdown-css-paths '("/global.css")))
     (markdown-test-temp-file "inline.text"
-      (setq-local markdown-css-paths '("./local.css"))
+      (setq-local markdown-css-paths '("/local.css"))
       (let* ((markdown-export-kill-buffer nil)
              (file (markdown-export))
              (buffer (get-file-buffer file)))
         (with-current-buffer buffer
           (goto-char (point-min))
-          (should (search-forward "href=\"./local.css\"")))
+          (should (search-forward "href=\"/local.css\"")))
+        (kill-buffer buffer)
+        (delete-file file)))))
+
+(ert-deftest test-markdown-export/relative-css-path ()
+  "Test relative `markdown-css-paths'."
+  (let ((markdown-css-paths '("style.css")))
+    (markdown-test-temp-file "inline.text"
+      (let* ((markdown-export-kill-buffer nil)
+             (file (markdown-export))
+             (buffer (get-file-buffer file))
+             (expanded-path (concat default-directory "style.css")))
+        (with-current-buffer buffer
+          (goto-char (point-min))
+          (should (search-forward (format "href=\"%s\"" expanded-path))))
         (kill-buffer buffer)
         (delete-file file)))))
 


### PR DESCRIPTION
## Description

Resolve style sheets in `markdown-css-paths` relative to the Markdown file

This fixes loading of "./stylesheet.css" from #834.

## Related Issue

#855

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
