### PR TITLE
Hide wiki markup as part of markdown-toggle-markup-hiding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
     - Added cmark and cmark-gfm to the markdown command list.
     - Disable `imenu-submenus-on-top` by default [GH-882][]
 
+  [gh-847]: https://github.com/jrblevin/markdown-mode/issues/847
   [gh-882]: https://github.com/jrblevin/markdown-mode/issues/882
   [gh-891]: https://github.com/jrblevin/markdown-mode/issues/891
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 
 *   Bug fixes:
     - `markdown-export` should not output stderr content to output file
+    - Hide wikilink markup as part of `markdown-toggle-markup-hiding` [GH-847][]
 
 *   Improvements:
     - Support drag and drop features on Windows and multiple files' drag and drop

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ using `package.el`. First, configure `package.el` and the MELPA Stable
 repository by adding the following to your `.emacs`, `init.el`,
 or equivalent startup file:
 
-```lisp
+```emacs-lisp
 (require 'package)
 (add-to-list 'package-archives
              '("melpa-stable" . "https://stable.melpa.org/packages/"))
@@ -79,7 +79,7 @@ then you can automatically install and configure `markdown-mode` by
 adding a declaration such as this one to your init file (as an
 example; adjust settings as desired):
 
-```lisp
+```emacs-lisp
 (use-package markdown-mode
   :ensure t
   :mode ("README\\.md\\'" . gfm-mode)
@@ -99,7 +99,7 @@ save the file where Emacs can find it (i.e., a directory in your
 `load-path`). You can then configure `markdown-mode` and `gfm-mode`
 to load automatically by adding the following to your init file:
 
-```lisp
+```emacs-lisp
 (autoload 'markdown-mode "markdown-mode"
    "Major mode for editing Markdown files" t)
 (add-to-list 'auto-mode-alist
@@ -133,7 +133,7 @@ repository as above or install markdown-mode from
 If you clone the repository directly, then make sure that Emacs can
 find it by adding the following line to your startup file:
 
-```lisp
+```emacs-lisp
 (add-to-list 'load-path "/path/to/markdown-mode/repository")
 ```
 
@@ -351,7 +351,7 @@ can obtain a list of all keybindings by pressing <kbd>C-c C-h</kbd>.
     preview window to appear at the bottom or right, you can
     customize `markdown-split-window-direction`.
 
-      ```lisp
+      ```emacs-lisp
       ;; Set custom markdown preview function
       (setq markdown-live-preview-window-function #'my-markdown-preview-function)
 
@@ -950,18 +950,17 @@ customization screen.
 
 [Marked 2]: https://itunes.apple.com/us/app/marked-2/id890031187?mt=12&uo=4&at=11l5Vs&ct=mm
 
-## Extensions
-
+## Wiki Links Customization
 Besides supporting the basic Markdown syntax, Markdown Mode also
 includes syntax highlighting for `[[Wiki Links]]`.  This can be
 enabled by setting `markdown-enable-wiki-links` to a non-nil value.
-Wiki links may be followed by pressing <kbd>C-c C-o</kbd> when the point
-is at a wiki link.  Use <kbd>M-p</kbd> and <kbd>M-n</kbd> to quickly jump to the
-previous and next links (including links of other types).
+
 Aliased or piped wiki links of the form `[[link text|PageName]]`
-are also supported.  Since some wikis reverse these components, set
+are supported.  Since some wikis reverse these components, set
 `markdown-wiki-link-alias-first` to nil to treat them as
-`[[PageName|link text]]`.  If `markdown-wiki-link-fontify-missing`
+`[[PageName|link text]]`.
+
+If `markdown-wiki-link-fontify-missing`
 is also non-nil, Markdown Mode will highlight wiki links with
 missing target file in a different color.  By default, Markdown
 Mode only searches for target files in the current directory.
@@ -972,17 +971,30 @@ This value type is a symbol list. Possible values are
 - `parent-directories` : search in parent directories
 - `project` : search under project root
 
-[SmartyPants][] support is possible by customizing `markdown-command`.
+## Extensions
+### SmartyPants
+
+[SmartyPants][] is a free tool for easily translating plain ASCII punctuation
+characters into "smart" typographic punctuation HTML entities. It can perform
+the following transformations:
+- straight quotes ( " and ' ) into “curly” quote HTML entities
+- backticks-style quotes (``like this'') into “curly” quote HTML entities
+- dashes (“--” and “---”) into en- and em-dash entities
+- three consecutive dots (“...”) into an ellipsis entity
+
+SmartyPants support is possible by customizing `markdown-command`.
 If you install `SmartyPants.pl` at, say, `/usr/local/bin/smartypants`,
 then you can set `markdown-command` to `"markdown | smartypants"`.
 You can do this either by using <kbd>M-x customize-group markdown</kbd>
 or by placing the following in your `.emacs` file:
 
-```lisp
+```emacs-lisp
 (setq markdown-command "markdown | smartypants")
 ```
 
 [SmartyPants]: http://daringfireball.net/projects/smartypants/
+
+### LaTeX Mathematical Expressions
 
 Syntax highlighting for mathematical expressions written
 in LaTeX (only expressions denoted by `$..$`, `$$..$$`, or `\[..\]`)
@@ -1066,7 +1078,7 @@ by `markdown-mode` and `gfm-mode` as described below.
   for line wrapping in buffers.  You can do this with a
   `gfm-mode-hook` as follows:
 
-    ```lisp
+    ```emacs-lisp
     ;; Use visual-line-mode in gfm-mode
     (defun my-gfm-mode-hook ()
       (visual-line-mode 1))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -10067,6 +10067,20 @@ rows and columns and the column alignment."
                    (propertize link 'face 'markdown-reference-face)
                    (propertize "]" 'face 'markdown-markup-face))
                 (propertize link 'face 'markdown-url-face)))))
+   ;; Hidden URL for wiki links
+   ((and (and markdown-enable-wiki-links
+              (thing-at-point-looking-at markdown-regex-wiki-link))
+         (or markdown-hide-urls markdown-hide-markup))
+    (let* ((imagep (string-equal (match-string 1) "!"))
+           (referencep (string-equal (match-string 5) "["))
+           (part1 (match-string-no-properties 3))
+           (part2 (match-string-no-properties 5))
+           (link (if markdown-wiki-link-alias-first part2 part1))
+           (edit-keys (markdown--substitute-command-keys
+                       "\\[markdown-insert-wiki-link]"))
+           (edit-str (propertize edit-keys 'face 'font-lock-constant-face)))
+      (format "Hidden URL (%s to edit): %s"
+              edit-str (propertize link 'face 'markdown-reference-face))))
    ;; Hidden language name for fenced code blocks
    ((and (markdown-code-block-at-point-p)
          (not (get-text-property (point) 'markdown-pre))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -262,7 +262,7 @@ This is the default search behavior of Ikiwiki."
   :package-version '(markdown-mode . "2.2"))
 
 (defcustom markdown-wiki-link-search-type nil
-  "Searching type for markdown wiki link.
+  "A list of options for searching for markdown wiki links.
 
 `sub-directories': search for wiki link targets in sub directories
 `parent-directories': search for wiki link targets in parent directories
@@ -8386,6 +8386,11 @@ The location of the alias component depends on the value of
     (or (match-string-no-properties 5) (match-string-no-properties 3))))
 
 (defun markdown--wiki-link-search-types ()
+  "Return a list of the currently selected search types.
+
+Due to deprecated variables, as of markdown-mode version 2.5, the return value
+of this function is the same as the value of the variable
+`markdown-wiki-link-search-type'."
   (let ((ret (and markdown-wiki-link-search-type
                   (cl-copy-list markdown-wiki-link-search-type))))
     (when (and markdown-wiki-link-search-subdirectories
@@ -8397,6 +8402,7 @@ The location of the alias component depends on the value of
     ret))
 
 (defun markdown--project-root ()
+  "Try various approaches to find the project root."
   (or (cl-loop for dir in '(".git" ".hg" ".svn")
                when (locate-dominating-file default-directory dir)
                return it)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -278,6 +278,16 @@ This is the default search behavior of Ikiwiki."
 (make-obsolete-variable 'markdown-wiki-link-search-subdirectories 'markdown-wiki-link-search-type "2.5")
 (make-obsolete-variable 'markdown-wiki-link-search-parent-directories 'markdown-wiki-link-search-type "2.5")
 
+(make-obsolete 'markdown-match-wiki-link nil "2.3")
+(make-obsolete 'markdown-highlight-wiki-link nil "2.3")
+(make-obsolete 'markdown-unfontify-region-wiki-links nil "2.3")
+(make-obsolete 'markdown-fontify-region-wiki-links nil "2.3")
+(make-obsolete 'markdown-extend-changed-region nil "2.3")
+(make-obsolete 'markdown-check-change-for-wiki-link nil "2.3")
+(make-obsolete 'markdown-check-change-for-wiki-link-after-change nil "2.3")
+(make-obsolete 'markdown-fontify-buffer-wiki-links nil "2.3")
+(make-obsolete 'markdown-setup-wiki-link-hooks nil "2.3")
+
 (defcustom markdown-wiki-link-fontify-missing nil
   "When non-nil, change wiki link face according to existence of target files.
 This is expensive because it requires checking for the file each time the buffer

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -907,7 +907,6 @@ This matches typical bracketed [[WikiLinks]] as well as \\='aliased
 wiki links of the form [[PageName|link text]].
 The meanings of the first and second components depend
 on the value of `markdown-wiki-link-alias-first'.
-
 Group 1 matches the entire link.
 Group 2 matches the opening square brackets.
 Group 3 matches the first component of the wiki link.
@@ -3387,7 +3386,8 @@ the buffer)."
   (when (and markdown-enable-wiki-links
              (not markdown-wiki-link-fontify-missing)
              (markdown-match-inline-generic markdown-regex-wiki-link last))
-    (let ((begin (match-beginning 1)) (end (match-end 1)))
+    (let ((begin (match-beginning 1))
+          (end (match-end 1)))
       (if (or (markdown-in-comment-p begin)
               (markdown-in-comment-p end)
               (markdown-inline-code-at-pos-p begin)
@@ -3396,6 +3396,25 @@ the buffer)."
           (progn (goto-char (min (1+ begin) last))
                  (when (< (point) last)
                    (markdown-match-wiki-link last)))
+        ;; Add text properties for hiding markup
+        (when markdown-hide-markup
+          (if markdown-wiki-link-alias-first
+              (progn
+                (add-text-properties (match-beginning 3) (match-end 3)
+                                     '(face markdown-link-face))
+                (add-text-properties (match-beginning 5) (match-end 5)
+                                     '(invisible markdown-markup face markdown-url-face)))
+            (progn
+              (add-text-properties (match-beginning 3) (match-end 3)
+                                   '(invisible markdown-markup face markdown-url-face))
+              (add-text-properties (match-beginning 5) (match-end 5)
+                                   '(face markdown-link-face))))
+          (add-text-properties (match-beginning 2) (match-end 2)
+                               '(invisible markdown-markup face markdown-markup-face))
+          (add-text-properties (match-beginning 4) (match-end 4)
+                               '(invisible markdown-markup face markdown-markup-face))
+          (add-text-properties (match-beginning 6) (match-end 6)
+                               '(invisible markdown-markup face markdown-markup-face)))
         (set-match-data (list begin end))
         t))))
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8199,10 +8199,6 @@ Translate filenames using `markdown-filename-translate-function'."
            (title-start (match-beginning 7))
            (title-end (match-end 7))
            (title (match-string-no-properties 7))
-           ;; Markup part
-           (mp (list 'invisible 'markdown-markup
-                     'rear-nonsticky t
-                     'font-lock-multiline t))
            ;; Link part (without face)
            (lp (list 'keymap markdown-mode-mouse-map
                      'font-lock-multiline t

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5211,8 +5211,7 @@ Otherwise, do normal delete by repeating
         (back-to-indentation)
         (unless (looking-at-p "[ \t]*$")
           (setq mincol (min mincol (current-column))))
-        (forward-line 1)
-        ))
+        (forward-line 1)))
     mincol))
 
 (defun markdown-indent-region (beg end arg)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -278,15 +278,15 @@ This is the default search behavior of Ikiwiki."
 (make-obsolete-variable 'markdown-wiki-link-search-subdirectories 'markdown-wiki-link-search-type "2.5")
 (make-obsolete-variable 'markdown-wiki-link-search-parent-directories 'markdown-wiki-link-search-type "2.5")
 
-(make-obsolete 'markdown-match-wiki-link nil "2.3")
-(make-obsolete 'markdown-highlight-wiki-link nil "2.3")
-(make-obsolete 'markdown-unfontify-region-wiki-links nil "2.3")
-(make-obsolete 'markdown-fontify-region-wiki-links nil "2.3")
-(make-obsolete 'markdown-extend-changed-region nil "2.3")
-(make-obsolete 'markdown-check-change-for-wiki-link nil "2.3")
-(make-obsolete 'markdown-check-change-for-wiki-link-after-change nil "2.3")
-(make-obsolete 'markdown-fontify-buffer-wiki-links nil "2.3")
-(make-obsolete 'markdown-setup-wiki-link-hooks nil "2.3")
+(make-obsolete 'markdown-match-wiki-link nil "2.8")
+(make-obsolete 'markdown-highlight-wiki-link nil "2.8")
+(make-obsolete 'markdown-unfontify-region-wiki-links nil "2.8")
+(make-obsolete 'markdown-fontify-region-wiki-links nil "2.8")
+(make-obsolete 'markdown-extend-changed-region nil "2.8")
+(make-obsolete 'markdown-check-change-for-wiki-link nil "2.8")
+(make-obsolete 'markdown-check-change-for-wiki-link-after-change nil "2.8")
+(make-obsolete 'markdown-fontify-buffer-wiki-links nil "2.8")
+(make-obsolete 'markdown-setup-wiki-link-hooks nil "2.8")
 
 (defcustom markdown-wiki-link-fontify-missing nil
   "When non-nil, change wiki link face according to existence of target files.

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -10071,9 +10071,7 @@ rows and columns and the column alignment."
    ((and (and markdown-enable-wiki-links
               (thing-at-point-looking-at markdown-regex-wiki-link))
          (or markdown-hide-urls markdown-hide-markup))
-    (let* ((imagep (string-equal (match-string 1) "!"))
-           (referencep (string-equal (match-string 5) "["))
-           (part1 (match-string-no-properties 3))
+    (let* ((part1 (match-string-no-properties 3))
            (part2 (match-string-no-properties 5))
            (link (if markdown-wiki-link-alias-first part2 part1))
            (edit-keys (markdown--substitute-command-keys

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8340,19 +8340,14 @@ Translate filenames using `markdown-filename-translate-function'."
           (url-end (match-end 2)))
       (unless (or (markdown-in-inline-code-p url-start)
                   (markdown-in-inline-code-p url-end))
-        (let* (;; Markup part
-               (mp (list 'face 'markdown-markup-face
-                         'invisible 'markdown-markup
-                         'rear-nonsticky t
-                         'font-lock-multiline t))
-               ;; URI part
+        (let* (;; URI part
                (up (list 'keymap markdown-mode-mouse-map
                          'face 'markdown-plain-url-face
                          'font-lock-multiline t)))
           (when markdown-mouse-follow-link
             (setq up (append up '(mouse-face markdown-highlight-face))))
           (dolist (g '(1 3))
-            (add-text-properties (match-beginning g) (match-end g) mp))
+            (add-text-properties (match-beginning g) (match-end g) markdown--markup-props))
           (add-text-properties url-start url-end up)
           t)))))
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8208,10 +8208,7 @@ Translate filenames using `markdown-filename-translate-function'."
                      'invisible 'markdown-markup
                      'font-lock-multiline t))
            ;; URL composition character
-           (url-char (markdown--first-displayable markdown-url-compose-char))
-           ;; Title part
-           (tp (list 'invisible 'markdown-markup
-                     'font-lock-multiline t)))
+           (url-char (markdown--first-displayable markdown-url-compose-char)))
       (when markdown-mouse-follow-link
         (setq lp (append lp '(mouse-face 'markdown-highlight-face)))
         (setq up (append up '(mouse-face 'markdown-highlight-face))))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3388,6 +3388,7 @@ the buffer)."
              (markdown-match-inline-generic markdown-regex-wiki-link last))
     (let ((begin (match-beginning 1))
           (end (match-end 1))
+          (aliasp (string-equal (match-string-no-properties 4) "|"))
           (part1 (match-string-no-properties 3))
           (part2 (match-string-no-properties 5)))
       (if (or (markdown-in-comment-p begin)
@@ -3400,16 +3401,18 @@ the buffer)."
                    (markdown-fontify-wiki-links last)))
         ;; Add text properties for hiding markup
         (progn
-          (if markdown-wiki-link-alias-first
-              (progn
-                (add-text-properties (match-beginning 3) (match-end 3) (link-props part2))
-                (add-text-properties (match-beginning 5) (match-end 5) url-props))
-            (progn
-              (add-text-properties (match-beginning 3) (match-end 3) url-props)
-              (add-text-properties (match-beginning 5) (match-end 5) (link-props part1))))
+          (if aliasp
+              (if markdown-wiki-link-alias-first
+                  (progn
+                    (add-text-properties (match-beginning 3) (match-end 3) (link-props part2))
+                    (add-text-properties (match-beginning 5) (match-end 5) url-props))
+                (progn
+                  (add-text-properties (match-beginning 3) (match-end 3) url-props)
+                  (add-text-properties (match-beginning 5) (match-end 5) (link-props part1))))
+            (add-text-properties (match-beginning 3) (match-end 3) (link-props part1)))
           (add-text-properties (match-beginning 2) (match-end 2) markup-props)
-          (add-text-properties (match-beginning 4) (match-end 4) markup-props)
-          (add-text-properties (match-beginning 6) (match-end 6) markup-props))
+          (add-text-properties (match-beginning 6) (match-end 6) markup-props)
+          (add-text-properties (match-beginning 4) (match-end 4) markup-props))
         (set-match-data (list begin end))
         t))))
 
@@ -10071,9 +10074,10 @@ rows and columns and the column alignment."
    ((and (and markdown-enable-wiki-links
               (thing-at-point-looking-at markdown-regex-wiki-link))
          (or markdown-hide-urls markdown-hide-markup))
-    (let* ((part1 (match-string-no-properties 3))
+    (let* ((aliasp (string-equal (match-string-no-properties 4) "|"))
+           (part1 (match-string-no-properties 3))
            (part2 (match-string-no-properties 5))
-           (link (if markdown-wiki-link-alias-first part2 part1))
+           (link (if (and aliasp markdown-wiki-link-alias-first) part2 part1))
            (edit-keys (markdown--substitute-command-keys
                        "\\[markdown-insert-wiki-link]"))
            (edit-str (propertize edit-keys 'face 'font-lock-constant-face)))

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1878,7 +1878,6 @@ to first convert to HTML or PDF (e.g,. using Pandoc)."
   :package-version '(markdown-mode . "2.3"))
 (make-variable-buffer-local 'markdown-hide-markup)
 
-;; TODO: nil does not work to disable hiding, only 0 or -1
 (defun markdown-toggle-markup-hiding (&optional arg)
   "Toggle the display or hiding of markup.
 With a prefix argument ARG, enable markup hiding if ARG is positive,
@@ -2293,9 +2292,7 @@ Depending on your font, some reasonable choices are:
     (markdown-fontify-sub-superscripts)
     (markdown-match-inline-attributes . ((0 markdown-markup-properties prepend)))
     (markdown-match-leanpub-sections . ((0 markdown-markup-properties)))
-    (markdown-fontify-blockquotes)
-    ;; (markdown-fontify-wiki-links)
-    )
+    (markdown-fontify-blockquotes))
   "Syntax highlighting for Markdown files.")
 
 ;; Footnotes
@@ -3289,7 +3286,6 @@ processed elements."
           ;; If no closing parenthesis in range, update continuation point
           (setq cont-point (min end-of-block second-begin))))
       (cond
-       ;; TODO: Is this why I enter an infinite loop?
        ;; On failure, continue searching at cont-point
        ((and cont-point (< cont-point last))
         (goto-char cont-point)
@@ -3391,9 +3387,6 @@ the buffer)."
              (markdown-match-inline-generic markdown-regex-wiki-link last))
     (let* ((begin (match-beginning 1))
            (end (match-end 1))
-
-           ;; (beg1 (match-beginning 1))
-           ;; (end1 (match-end 1))
            (beg2 (match-beginning 2))
            (end2 (match-end 2))
            (beg3 (match-beginning 3))
@@ -3404,7 +3397,6 @@ the buffer)."
            (end5 (match-end 5))
            (beg6 (match-beginning 6))
            (end6 (match-end 6))
-
            (part1 (match-string-no-properties 3))
            (part2 (match-string-no-properties 5))
            (aliasp (string-equal (match-string-no-properties 4) "|"))
@@ -3430,16 +3422,10 @@ the buffer)."
                       (if (and file-missing-p markdown-wiki-link-fontify-missing)
                           (progn
                             (add-text-properties beg3 end3 (missing-link-props part2))
-                            ;; (add-face-text-property beg3 end3 'markdown-missing-link-face)
-                            (put-text-property beg3 end3 'font-lock-face 'markdown-missing-link-face)
-                            ;; (put-text-property beg3 end3 'face 'markdown-missing-link-face)
-                            )
+                            (put-text-property beg3 end3 'font-lock-face 'markdown-missing-link-face))
                         (progn
                           (add-text-properties beg3 end3 (link-props part2))
-                          ;; (add-face-text-property beg3 end3 'markdown-link-face)
-                          (put-text-property beg3 end3 'font-lock-face 'markdown-link-face)
-                          ;; (put-text-property beg3 end3 'face 'markdown-link-face)
-                          ))
+                          (put-text-property beg3 end3 'font-lock-face 'markdown-link-face)))
                       (progn
                         (add-text-properties beg5 end5 url-props)
                         (add-face-text-property beg5 end5 'markdown-url-face)))
@@ -3449,29 +3435,17 @@ the buffer)."
                     (if (and file-missing-p markdown-wiki-link-fontify-missing)
                         (progn
                           (add-text-properties beg5 end5 (missing-link-props part1))
-                          ;; (add-face-text-property beg5 end5 'markdown-missing-link-face)
-                          (put-text-property beg5 end5 'font-lock-face 'markdown-missing-link-face)
-                          ;; (put-text-property beg5 end5 'face 'markdown-missing-link-face)
-                          )
+                          (put-text-property beg5 end5 'font-lock-face 'markdown-missing-link-face))
                       (progn
                         (add-text-properties beg5 end5 (link-props part1))
-                        ;; (add-face-text-property beg5 end5 'markdown-link-face)
-                        (put-text-property beg5 end5 'font-lock-face 'markdown-link-face)
-                        ;; (put-text-property beg5 end5 'face 'markdown-link-face)
-                        )))))
+                        (put-text-property beg5 end5 'font-lock-face 'markdown-link-face))))))
             (if (and file-missing-p markdown-wiki-link-fontify-missing)
                 (progn
                   (add-text-properties beg3 end3 (missing-link-props part1))
-                  ;; (add-face-text-property beg3 end3 'markdown-missing-link-face)
-                  (put-text-property beg3 end3 'font-lock-face 'markdown-missing-link-face)
-                  ;; (put-text-property beg3 end3 'face 'markdown-missing-link-face)
-                  )
+                  (put-text-property beg3 end3 'font-lock-face 'markdown-missing-link-face))
               (progn
                 (add-text-properties beg3 end3 (link-props part1))
-                ;; (add-face-text-property beg3 end3 'markdown-link-face)
-                (put-text-property beg3 end3 'font-lock-face 'markdown-link-face)
-                ;; (put-text-property beg3 end3 'face 'markdown-link-face)
-                )))
+                (put-text-property beg3 end3 'font-lock-face 'markdown-link-face))))
           ;; Propertize opening and closing brackets
           (add-text-properties beg2 end2 markup-props)
           (add-text-properties beg6 end6 markup-props)
@@ -8141,7 +8115,6 @@ update this buffer's contents."
 
 ;;; Links =====================================================================
 
-;; TODO: Is this why I get an infinite loop when searching for links?
 (defun markdown-backward-to-link-start ()
   "Backward link start position if current position is in link title."
   ;; Issue #305
@@ -8256,45 +8229,32 @@ Translate filenames using `markdown-filename-translate-function'."
           (markdown--browse-url (markdown-link-url)))
     (user-error "Point is not at a Markdown link or URL")))
 
-
-(defconst markup-props (list ;; 'face 'markdown-markup-face
-                             'invisible 'markdown-markup
+(defconst markup-props (list 'invisible 'markdown-markup
                              'rear-nonsticky t
                              'font-lock-multiline t))
-;; (add-face-text-property (match-beginning g) (match-end g) 'markdown-markup-face)
 
-(defconst url-props (list ;; 'face 'markdown-url-face
-                          'invisible 'markdown-markup
+(defconst url-props (list 'invisible 'markdown-markup
                           'keymap markdown-mode-mouse-map
                           'mouse-face 'markdown-highlight-face
                           'font-lock-multiline t))
-;; (add-face-text-property url-start url-end 'markdown-url-face)
 
-(defconst title-props (list ;; 'face 'markdown-link-title-face
-                            'invisible 'markdown-markup
+(defconst title-props (list 'invisible 'markdown-markup
                             'font-lock-multiline t))
-;; (add-face-text-property url-end title-end 'markdown-link-title-face)
 
 (defun link-props (url &optional title)
   "Return a property list for URL with optional TITLE."
   (let ((echo-text (if title (concat title "\n" url) url)))
-    (list ;; 'face 'markdown-link-face
-          'keymap markdown-mode-mouse-map
-          ;; 'mouse-face markdown-highlight-face
+    (list 'keymap markdown-mode-mouse-map
           'mouse-face 'markdown-highlight-face
           'font-lock-multiline t
           'help-echo echo-text)))
-;; (add-face-text-property link-start link-end 'markdown-link-face)
 
 (defun missing-link-props (url)
   "Return a property list for URL for file that doesn't exist."
-  (list ;; 'face 'markdown-missing-link-face
-        'keymap markdown-mode-mouse-map
+  (list 'keymap markdown-mode-mouse-map
         'mouse-face 'markdown-highlight-face
         'font-lock-multiline t
         'help-echo url))
-;; (add-face-text-property link-start link-end 'markdown-missing-link-face)
-
 
 (defun markdown-fontify-inline-links (last)
   "Add text properties to next inline link from point to LAST."
@@ -8541,6 +8501,16 @@ See `markdown-wiki-link-p' and `markdown-follow-wiki-link'."
       (markdown-follow-wiki-link (markdown-wiki-link-link) arg)
     (user-error "Point is not at a Wiki Link")))
 
+(defun markdown-unfontify-region-wiki-links (from to)
+  "Remove wiki link faces from the region specified by FROM and TO."
+  (interactive "*r")
+  (let ((modified (buffer-modified-p)))
+    (remove-text-properties from to '(font-lock-face markdown-link-face))
+    (remove-text-properties from to '(font-lock-face markdown-missing-link-face))
+    ;; remove-text-properties marks the buffer modified in emacs 24.3,
+    ;; undo that if it wasn't originally marked modified
+    (set-buffer-modified-p modified)))
+
 (defun markdown-fontify-region-wiki-links (from to)
   "Search region given by FROM and TO for wiki links and fontify them.
 If a wiki link is found check to see if the backing file exists
@@ -8559,19 +8529,6 @@ and highlight accordingly."
                highlight-beginning highlight-end 'font-lock-face 'markdown-link-face)
             (put-text-property
              highlight-beginning highlight-end 'font-lock-face 'markdown-missing-link-face)))))))
-
-;; TODO: Need to handle this function for a complete solution
-(defun markdown-unfontify-region-wiki-links (from to)
-  "Remove wiki link faces from the region specified by FROM and TO."
-  (interactive "*r")
-  (let ((modified (buffer-modified-p)))
-    (remove-text-properties from to '(font-lock-face markdown-link-face))
-    (remove-text-properties from to '(font-lock-face markdown-missing-link-face))
-    ;; (remove-text-properties from to '(face markdown-link-face))
-    ;; (remove-text-properties from to '(face markdown-missing-link-face))
-    ;; remove-text-properties marks the buffer modified in emacs 24.3,
-    ;; undo that if it wasn't originally marked modified
-    (set-buffer-modified-p modified)))
 
 (defun markdown-extend-changed-region (from to)
   "Extend region given by FROM and TO so that we can fontify all links.
@@ -8613,7 +8570,6 @@ newline after."
                 ;; wiki link face or if the wiki link regexp matches.
                 (when (or (markdown-range-property-any
                            new-from new-to 'font-lock-face
-                           ;; new-from new-to 'face
                            '(markdown-link-face markdown-missing-link-face))
                           (re-search-forward
                            markdown-regex-wiki-link new-to t))
@@ -8673,7 +8629,6 @@ These are only enabled when `markdown-wiki-link-fontify-missing' is non-nil."
   ;; refontified when we come back.
   (if (and markdown-enable-wiki-links
            markdown-wiki-link-fontify-missing)
-
       (progn
         (add-hook 'after-change-functions
                   #'markdown-check-change-for-wiki-link-after-change t t)

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -264,9 +264,9 @@ This is the default search behavior of Ikiwiki."
 (defcustom markdown-wiki-link-search-type nil
   "Searching type for markdown wiki link.
 
-sub-directories: search for wiki link targets in sub directories
-parent-directories: search for wiki link targets in parent directories
-project: search for wiki link targets under project root"
+`sub-directories': search for wiki link targets in sub directories
+`parent-directories': search for wiki link targets in parent directories
+`project': search for wiki link targets under project root"
   :group 'markdown
   :type '(set
           (const :tag "search wiki link from subdirectories" sub-directories)
@@ -8273,7 +8273,6 @@ Translate filenames using `markdown-filename-translate-function'."
         ;; Add text properties for hiding markup
         (progn
           ;; Propertize opening and closing brackets
-          (remove-text-properties begin end '(font-lock-face nil))
           (add-text-properties    beg2 end2 markdown--markup-props)
           (add-face-text-property beg2 end2 'markdown-markup-face)
           (add-text-properties    beg6 end6 markdown--markup-props)
@@ -8292,7 +8291,7 @@ Translate filenames using `markdown-filename-translate-function'."
                       (add-text-properties    beg5 end5 '(invisible markdown-markup))
                       (add-face-text-property beg5 end5 'markdown-url-face)
                       (when (and file-missing-p markdown-wiki-link-fontify-missing)
-                        (put-text-property beg3 end3 'font-lock-face 'markdown-missing-link-face)))
+                        (put-text-property beg3 end3 'face 'markdown-missing-link-face)))
                   (progn
                     ;; Properties URL portion of link
                     (add-text-properties    beg3 end3 markdown--url-props)
@@ -8301,13 +8300,13 @@ Translate filenames using `markdown-filename-translate-function'."
                     (add-text-properties    beg5 end5 (markdown--link-props part1))
                     (add-face-text-property beg5 end5 'markdown-link-face)
                     (when (and file-missing-p markdown-wiki-link-fontify-missing)
-                      (put-text-property beg5 end5 'font-lock-face 'markdown-missing-link-face)))))
+                      (put-text-property beg5 end5 'face 'markdown-missing-link-face)))))
             (progn
               ;; Properties link as link text
               (add-text-properties    beg3 end3 (markdown--link-props part1))
               (add-face-text-property beg3 end3 'markdown-link-face)
               (when (and file-missing-p markdown-wiki-link-fontify-missing)
-                (put-text-property beg3 end3 'font-lock-face 'markdown-missing-link-face)))))
+                (put-text-property beg3 end3 'face 'markdown-missing-link-face)))))
         (set-match-data (list begin end))
         t))))
 
@@ -8412,12 +8411,9 @@ The location of the alias component depends on the value of
 (defun markdown-convert-wiki-link-to-filename (name)
   "Generate a filename from the wiki link NAME.
 Spaces in NAME are replaced with `markdown-link-space-sub-char'.
+Search depth is determined by `markdown-wiki-link-search-type'.
 When in `gfm-mode', follow GitHub's conventions where [[Test Test]]
-and [[test test]] both map to Test-test.ext.  Look in the current
-directory first, then in subdirectories if
-`markdown-wiki-link-search-subdirectories' is non-nil, and then
-in parent directories if
-`markdown-wiki-link-search-parent-directories' is non-nil."
+and [[test test]] both map to Test-test.ext."
   (save-match-data
     ;; This function must not overwrite match data(PR #590)
     (let* ((basename (replace-regexp-in-string
@@ -8510,20 +8506,6 @@ and disable it otherwise."
           (> (prefix-numeric-value arg) 0)))
   (when (called-interactively-p 'interactive)
     (message "markdown-mode wiki link support %s"
-             (if markdown-enable-wiki-links "enabled" "disabled")))
-  (markdown-reload-extensions))
-
-(defun markdown-toggle-fontify-missing-wiki-links (&optional arg)
-  "Toggle wiki link face to show whether or not target file exists.
-With a prefix argument ARG, enable missing link fontification if ARG
-is positive,and disable it otherwise."
-  (interactive (list (or current-prefix-arg 'toggle)))
-  (setq markdown-wiki-link-fontify-missing
-        (if (eq arg 'toggle)
-            (not markdown-wiki-link-fontify-missing)
-          (> (prefix-numeric-value arg) 0)))
-  (when (called-interactively-p 'interactive)
-    (message "markdown-mode fontification of missing wiki links %s"
              (if markdown-enable-wiki-links "enabled" "disabled")))
   (markdown-reload-extensions))
 

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5761,6 +5761,112 @@ http://example.com \"title\"  )
         (call-interactively 'markdown-kill-thing-at-point)
         (should (string-equal (current-kill 0) (cdr test)))))))
 
+(ert-deftest test-markdown/wiki-link-rules ()
+  "Test wiki link search rules and font lock for missing pages."
+  (let ((markdown-enable-wiki-links t)
+        (markdown-wiki-link-fontify-missing t)
+        (markdown-wiki-link-search-type '(project)))
+    (progn
+      (find-file (expand-file-name "wiki/root" markdown-test-dir))
+      (unwind-protect
+          (progn
+            (markdown-mode)
+            (font-lock-ensure)
+            ;; search rules
+            (should (string-match-p
+                     "/sub/foo$"
+                     (markdown-convert-wiki-link-to-filename "foo")))
+            (should (string-equal
+                     (markdown-convert-wiki-link-to-filename "doesnotexist")
+                     "doesnotexist"))
+            ;; font lock
+            (markdown-test-range-has-property  1  2 'face 'markdown-markup-face)
+            (markdown-test-range-has-property  3  9 'face 'markdown-link-face)
+            (markdown-test-range-has-property 10 11 'face 'markdown-markup-face)
+            (markdown-test-range-has-property 16 31 'face 'markdown-missing-link-face)
+            (markdown-test-range-has-property 38 40 'face 'markdown-link-face)
+            (markdown-test-range-has-property 47 58 'face 'markdown-missing-link-face)
+            (markdown-test-range-has-property 65 74 'face 'markdown-link-face))
+        (kill-buffer)))
+    (progn
+      (find-file (expand-file-name "wiki/sub/foo" markdown-test-dir))
+      (unwind-protect
+          (progn
+            (markdown-mode)
+            (font-lock-ensure)
+            ;; search rules
+            (should (string-match-p
+                     "/wiki/root$"
+                     (markdown-convert-wiki-link-to-filename "root")))
+            (should (string-equal
+                     (markdown-convert-wiki-link-to-filename "doesnotexist")
+                     "doesnotexist"))
+            ;; font lock
+            (markdown-test-range-has-property  3 14 'face 'markdown-missing-link-face)
+            (markdown-test-range-has-property 21 24 'face 'markdown-link-face))
+        (kill-buffer)))))
+
+(ert-deftest test-markdown/wiki-link-keep-match-data ()
+  "Test that markdown-wiki-link-p keeps expected match data.
+Detail: https://github.com/jrblevin/markdown-mode/pull/590"
+  (let ((markdown-enable-wiki-links t)
+        (markdown-link-space-sub-char " ")
+        (markdown-wiki-link-search-type '(sub-directories)))
+    (progn
+      (find-file (expand-file-name "wiki/pr590/Guide.md" markdown-test-dir))
+      (unwind-protect
+          (progn
+            (markdown-mode)
+            (re-search-forward "Zettel Markdown")
+            (goto-char (match-beginning 0))
+            (should (markdown-wiki-link-p)) ;; create match-data
+            (should (string= (markdown-wiki-link-link) "Zettel Markdown")))
+        (kill-buffer)))))
+
+(ert-deftest test-markdown/wiki-link-search-under-project ()
+  "Test that searching link under project root."
+  (let ((markdown-enable-wiki-links t)
+        (markdown-link-space-sub-char " ")
+        (markdown-wiki-link-search-type '(project))
+        (expected (expand-file-name "wiki/pr590/Guide/Zettel Markdown/math.md"
+                                    markdown-test-dir)))
+    (progn
+      (find-file (expand-file-name "wiki/pr590/Guide/Plugin/Link.md" markdown-test-dir))
+      (unwind-protect
+          (progn
+            (markdown-mode)
+            (re-search-forward "math")
+            (goto-char (match-beginning 0))
+            (markdown-wiki-link-p) ;; create match-data
+            (let ((link (markdown-convert-wiki-link-to-filename (markdown-wiki-link-link))))
+              (should (string= (expand-file-name link) expected))))
+        (kill-buffer)))))
+
+(ert-deftest test-markdown/wiki-link-major-mode ()
+  "Test major-mode of linked page."
+  (let ((markdown-enable-wiki-links t)
+        (auto-mode-alist (cons '("bar\\.md" . gfm-mode) auto-mode-alist)))
+    (find-file (expand-file-name "wiki/root" markdown-test-dir))
+    (unwind-protect
+        (progn
+          (markdown-mode)
+          (search-forward "sub/bar.md")
+          (markdown-follow-wiki-link-at-point)
+          (should (eq major-mode 'gfm-mode)))
+      (kill-buffer))))
+
+(ert-deftest test-markdown/wiki-link-nonexistent-file ()
+  "Test following wiki link to nonexistent file visits the buffer."
+  (let ((markdown-enable-wiki-links t))
+    (find-file (expand-file-name "wiki/foo.md" markdown-test-dir))
+    (unwind-protect
+        (progn
+          (markdown-mode)
+          (search-forward "[[doesnotexist]]")
+          (markdown-follow-wiki-link-at-point)
+          (should (string= (buffer-name) "doesnotexist.md")))
+      (kill-buffer))))
+
 ;;; Filling tests:
 
 (ert-deftest test-markdown-filling/blockquote ()
@@ -7018,110 +7124,6 @@ x|"
     (should (string-equal (buffer-string) " #. abc\n def\n"))
     (markdown-indent-region (line-beginning-position) (line-end-position) nil)
     (should (string-equal (buffer-string) " #. abc\n    def\n"))))
-
-(ert-deftest test-markdown-ext/wiki-link-rules ()
-  "Test wiki link search rules and font lock for missing pages."
-  (let ((markdown-enable-wiki-links t)
-        (markdown-wiki-link-fontify-missing t)
-        (markdown-wiki-link-search-type '(project)))
-    (progn
-      (find-file (expand-file-name "wiki/root" markdown-test-dir))
-      (unwind-protect
-          (progn
-            (markdown-mode)
-            (font-lock-ensure)
-            ;; search rules
-            (should (string-match-p
-                     "/sub/foo$"
-                     (markdown-convert-wiki-link-to-filename "foo")))
-            (should (string-equal
-                     (markdown-convert-wiki-link-to-filename "doesnotexist")
-                     "doesnotexist"))
-            ;; font lock
-            (markdown-test-range-has-property  3  9 'face 'markdown-link-face)
-            (markdown-test-range-has-property 16 31 'face 'markdown-missing-link-face)
-            (markdown-test-range-has-property 38 40 'face 'markdown-link-face)
-            (markdown-test-range-has-property 47 58 'face 'markdown-missing-link-face)
-            (markdown-test-range-has-property 65 74 'face 'markdown-link-face))
-        (kill-buffer)))
-    (progn
-      (find-file (expand-file-name "wiki/sub/foo" markdown-test-dir))
-      (unwind-protect
-          (progn
-            (markdown-mode)
-            (font-lock-ensure)
-            ;; search rules
-            (should (string-match-p
-                     "/wiki/root$"
-                     (markdown-convert-wiki-link-to-filename "root")))
-            (should (string-equal
-                     (markdown-convert-wiki-link-to-filename "doesnotexist")
-                     "doesnotexist"))
-            ;; font lock
-            (markdown-test-range-has-property  3 14 'face 'markdown-missing-link-face)
-            (markdown-test-range-has-property 21 24 'face 'markdown-link-face))
-        (kill-buffer)))))
-
-(ert-deftest test-markdown-ext/wiki-link-keep-match-data ()
-  "Test that markdown-wiki-link-p keeps expected match data.
-Detail: https://github.com/jrblevin/markdown-mode/pull/590"
-  (let ((markdown-enable-wiki-links t)
-        (markdown-link-space-sub-char " ")
-        (markdown-wiki-link-search-type '(sub-directories)))
-    (progn
-      (find-file (expand-file-name "wiki/pr590/Guide.md" markdown-test-dir))
-      (unwind-protect
-          (progn
-            (markdown-mode)
-            (re-search-forward "Zettel Markdown")
-            (goto-char (match-beginning 0))
-            (should (markdown-wiki-link-p)) ;; create match-data
-            (should (string= (markdown-wiki-link-link) "Zettel Markdown")))
-        (kill-buffer)))))
-
-(ert-deftest test-markdown-ext/wiki-link-search-under-project ()
-  "Test that searching link under project root."
-  (let ((markdown-enable-wiki-links t)
-        (markdown-link-space-sub-char " ")
-        (markdown-wiki-link-search-type '(project))
-        (expected (expand-file-name "wiki/pr590/Guide/Zettel Markdown/math.md"
-                                    markdown-test-dir)))
-    (progn
-      (find-file (expand-file-name "wiki/pr590/Guide/Plugin/Link.md" markdown-test-dir))
-      (unwind-protect
-          (progn
-            (markdown-mode)
-            (re-search-forward "math")
-            (goto-char (match-beginning 0))
-            (markdown-wiki-link-p) ;; create match-data
-            (let ((link (markdown-convert-wiki-link-to-filename (markdown-wiki-link-link))))
-              (should (string= (expand-file-name link) expected))))
-        (kill-buffer)))))
-
-(ert-deftest test-markdown-ext/wiki-link-major-mode ()
-  "Test major-mode of linked page."
-  (let ((markdown-enable-wiki-links t)
-        (auto-mode-alist (cons '("bar\\.md" . gfm-mode) auto-mode-alist)))
-    (find-file (expand-file-name "wiki/root" markdown-test-dir))
-    (unwind-protect
-        (progn
-          (markdown-mode)
-          (search-forward "sub/bar.md")
-          (markdown-follow-wiki-link-at-point)
-          (should (eq major-mode 'gfm-mode)))
-      (kill-buffer))))
-
-(ert-deftest test-markdown-ext/wiki-link-nonexistent-file ()
-  "Test following wiki link to nonexistent file visits the buffer."
-  (let ((markdown-enable-wiki-links t))
-    (find-file (expand-file-name "wiki/foo.md" markdown-test-dir))
-    (unwind-protect
-        (progn
-          (markdown-mode)
-          (search-forward "[[doesnotexist]]")
-          (markdown-follow-wiki-link-at-point)
-          (should (string= (buffer-name) "doesnotexist.md")))
-      (kill-buffer))))
 
 (defun markdown-test-live-preview-window-eww (_orig-fun &rest _args)
   (get-buffer-create "*eww*"))

--- a/tests/wiki-links.text
+++ b/tests/wiki-links.text
@@ -9,7 +9,7 @@ point 155.
 Bracketed expressions in code blocks should not be matched as wiki
 links:
 
-```
+```clojure
 {
  :user {
    :repositories [["clojars" {:sign-releases false}]]


### PR DESCRIPTION
When markup hiding is enabled, the markup for markdown-style links is hidden, but the markup for wiki links is not.  This code change fontifies the different sections of wiki links so that they are properly supported by `markdown-toggle-markup-hiding`.

## Related Issues

The changes address issues #557, #782, and #847.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [X] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed (using `make test`).
