### PR TITLE
Make it possible to use style sheet URLs again

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@
     - Change temporary buffer name according to the Emacs naming convention [GH-848][]
     - Mark `markdown-css-paths` safe as file local variables [GH-834][]
     - Resolve style sheets in `markdown-css-paths` relative to the Markdown file
-      [GH-855][]
+      (if the path starts with `./` or `../`) [GH-855][] [GH-870][]
 
   [gh-780]: https://github.com/jrblevin/markdown-mode/issues/780
   [gh-802]: https://github.com/jrblevin/markdown-mode/issues/802
@@ -43,6 +43,7 @@
   [gh-845]: https://github.com/jrblevin/markdown-mode/issues/845
   [gh-848]: https://github.com/jrblevin/markdown-mode/issues/848
   [gh-855]: https://github.com/jrblevin/markdown-mode/issues/855
+  [gh-870]: https://github.com/jrblevin/markdown-mode/issues/870
 
 # Markdown Mode 2.6
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7736,7 +7736,9 @@ Standalone XHTML output is identified by an occurrence of
 
 (defun markdown-stylesheet-link-string (stylesheet-path)
   (concat "<link rel=\"stylesheet\" type=\"text/css\" media=\"all\" href=\""
-          (expand-file-name stylesheet-path)
+          (or (and (string-match-p (rx (or "~" "./" "../")) stylesheet-path)
+                   (expand-file-name stylesheet-path))
+              stylesheet-path)
           "\"  />"))
 
 (defun markdown-escape-title (title)

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -6182,6 +6182,19 @@ bar baz"
       (kill-buffer obuffer)
       (delete-file ofile))))
 
+(ert-deftest test-markdown-export/url-css-path ()
+  "Test `markdown-css-paths' as URL."
+  (let ((markdown-css-paths '("http://www.example.com/style.css")))
+    (markdown-test-temp-file "inline.text"
+      (let* ((markdown-export-kill-buffer nil)
+             (file (markdown-export))
+             (buffer (get-file-buffer file)))
+        (with-current-buffer buffer
+          (goto-char (point-min))
+          (should (search-forward "href=\"http://www.example.com/style.css\"")))
+        (kill-buffer buffer)
+        (delete-file file)))))
+
 (ert-deftest test-markdown-export/buffer-local-css-path ()
   "Test buffer local `markdown-css-paths'"
   (let ((markdown-css-paths '("/global.css")))
@@ -6198,7 +6211,7 @@ bar baz"
 
 (ert-deftest test-markdown-export/relative-css-path ()
   "Test relative `markdown-css-paths'."
-  (let ((markdown-css-paths '("style.css")))
+  (let ((markdown-css-paths '("./style.css")))
     (markdown-test-temp-file "inline.text"
       (let* ((markdown-export-kill-buffer nil)
              (file (markdown-export))


### PR DESCRIPTION
Only expand `markdown-css-paths` that clearly are relative.

## Description

This disables the *unreleased* support for relative paths without a `./`, `../` or `~` prefix.

Add an extra `markdown-css-paths` test that ensures we don't break URL support going forward.


## Related Issue

Fixes #869.

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
