### PR TITLE
Add defcustom markdown-wiki-link-retain-case

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
     - Trailing whitespace characters for line breaks are hidden when using
       `markdown-hide-markup`
     - `fill-paragraph` considers GFM alert syntax [GH-838][]
+    - Add new flag `markdown-wiki-link-retain-case` [GH-839][]
 
 *   Bug fixes:
     - Don't highlight superscript/subscript in math inline/block [GH-802][]
@@ -40,6 +41,7 @@
   [gh-827]: https://github.com/jrblevin/markdown-mode/issues/827
   [gh-834]: https://github.com/jrblevin/markdown-mode/issues/834
   [gh-838]: https://github.com/jrblevin/markdown-mode/issues/838
+  [gh-839]: https://github.com/jrblevin/markdown-mode/issues/839
   [gh-845]: https://github.com/jrblevin/markdown-mode/issues/845
   [gh-848]: https://github.com/jrblevin/markdown-mode/issues/848
   [gh-855]: https://github.com/jrblevin/markdown-mode/issues/855

--- a/README.md
+++ b/README.md
@@ -772,6 +772,9 @@ provides an interface to all of the possible customizations:
     (default: `t`).  When set to nil, they will be treated as
     `[[PageName|link text]]`.
 
+  * `markdown-wiki-link-retain-case nil` - set a non-nil value not to
+     change wiki link file name case
+
   * `markdown-uri-types` - a list of protocol schemes (e.g., "http")
     for URIs that `markdown-mode` should highlight.
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -287,6 +287,13 @@ cause lag when typing on slower machines."
   :safe 'booleanp
   :package-version '(markdown-mode . "2.2"))
 
+(defcustom markdown-wiki-link-retain-case nil
+  "When non-nil, wiki link file names do not have their case changed."
+  :group 'markdown
+  :type 'boolean
+  :safe 'booleanp
+  :package-version '(markdown-mode . "2.7"))
+
 (defcustom markdown-uri-types
   '("acap" "cid" "data" "dav" "fax" "file" "ftp"
     "geo" "gopher" "http" "https" "imap" "ldap" "mailto"
@@ -8374,10 +8381,12 @@ in parent directories if
     ;; This function must not overwrite match data(PR #590)
     (let* ((basename (replace-regexp-in-string
                       "[[:space:]\n]" markdown-link-space-sub-char name))
-           (basename (if (derived-mode-p 'gfm-mode)
-                         (concat (upcase (substring basename 0 1))
-                                 (downcase (substring basename 1 nil)))
-                       basename))
+           (basename (if markdown-wiki-link-retain-case
+                         basename
+                       (if (derived-mode-p 'gfm-mode)
+                           (concat (upcase (substring basename 0 1))
+                                   (downcase (substring basename 1 nil)))
+                         basename)))
            (search-types (markdown--wiki-link-search-types))
            directory extension default candidates dir)
       (when buffer-file-name

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -8381,12 +8381,10 @@ in parent directories if
     ;; This function must not overwrite match data(PR #590)
     (let* ((basename (replace-regexp-in-string
                       "[[:space:]\n]" markdown-link-space-sub-char name))
-           (basename (if markdown-wiki-link-retain-case
-                         basename
-                       (if (derived-mode-p 'gfm-mode)
-                           (concat (upcase (substring basename 0 1))
-                                   (downcase (substring basename 1 nil)))
-                         basename)))
+           (basename (if (and (derived-mode-p 'gfm-mode) (not markdown-wiki-link-retain-case))
+                         (concat (upcase (substring basename 0 1))
+                                 (downcase (substring basename 1 nil)))
+                       basename))
            (search-types (markdown--wiki-link-search-types))
            directory extension default candidates dir)
       (when buffer-file-name

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -7123,6 +7123,25 @@ Detail: https://github.com/jrblevin/markdown-mode/pull/590"
               (should (string= (expand-file-name link) expected))))
         (kill-buffer)))))
 
+(ert-deftest test-markdown-ext/wiki-link-retain-case ()
+  "Test that searching link under project root."
+  (let ((markdown-wiki-link-retain-case nil))
+    (find-file "wiki/pr666/jump_wiki_link.md")
+    (unwind-protect
+        (progn
+          (gfm-mode)
+          (let ((link-file-name (markdown-convert-wiki-link-to-filename "FOOBAR")))
+            (should (string= "Foobar.md" (file-name-nondirectory link-file-name)))))
+      (kill-buffer)))
+  (let ((markdown-wiki-link-retain-case t))
+    (find-file "wiki/pr666/jump_wiki_link.md")
+    (unwind-protect
+        (progn
+          (gfm-mode)
+          (let ((link-file-name (markdown-convert-wiki-link-to-filename "FOOBAR")))
+            (should (string= "FOOBAR.md" (file-name-nondirectory link-file-name)))))
+      (kill-buffer))))
+
 (ert-deftest test-markdown-ext/wiki-link-major-mode ()
   "Test major-mode of linked page."
   (let ((markdown-enable-wiki-links t)


### PR DESCRIPTION
## Description

This option to nil to retain existing behavior. When set to t, it prevents markdown-convert-wiki-link-to-filename from altering the case of the user's input.

<!-- More detailed description of the changes if needed. -->

## Related Issue

Satisfies #839.

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.

Looks like this hasn't been happening recently. Happy to.

- [ ] I have added an entry to **CHANGES.md**.

Ditto.

- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed (using `make test`).

Should add this option:
- [X] byte compiler run with no warnings or errors.