### PR TITLE
Add defun markdown-is-fontify-buffer-p

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9156,10 +9156,6 @@ Example:
   (buffer-local-value 'markdown--is-fontify-buffer
                       (or buffer (current-buffer))))
 
-(unless (and (featurep 'markdown-mode)
-             (markdown-is-fontify-buffer-p))
-  (eglot-ensure))
-
 ;; Based on `org-src-font-lock-fontify-block' from org-src.el.
 (defun markdown-fontify-code-block-natively (lang start end)
   "Fontify given GFM or fenced code block.

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9150,7 +9150,7 @@ This is useful in a `prog-mode' hook to avoid resource-intensive
 features such as `eglot' inside a fontification buffer.
 
 Example:
-  (unless (and (featurep 'markdown-mode)
+  (unless (and (featurep \\='markdown-mode)
                (markdown-is-fontify-buffer-p))
     (eglot-ensure))"
   (buffer-local-value 'markdown--is-fontify-buffer


### PR DESCRIPTION
This is extremely useful in a `prog-mode' hook to avoid resource-intensive features such as `eglot' inside a fontification buffer.

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed (using `make test`).
