### PR TITLE
Don't break inline-code rendering when there's a <foo:bar>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
       and `markdown-fontify-code-blocks-natively` together [GH-766][]
     - Fix `markdown-fontify-whole-heading-line` regression [GH-848][]
     - Fix using fundamental-mode issue when editting code block [GH-868][]
+    - Fix highlighting URL in angle brackes[GH-822][]
 
 *   Improvements:
     - Apply url-unescape against URL in an inline link [GH-805][]
@@ -40,6 +41,7 @@
   [gh-804]: https://github.com/jrblevin/markdown-mode/issues/804
   [gh-805]: https://github.com/jrblevin/markdown-mode/issues/805
   [gh-817]: https://github.com/jrblevin/markdown-mode/issues/817
+  [gh-822]: https://github.com/jrblevin/markdown-mode/issues/822
   [gh-827]: https://github.com/jrblevin/markdown-mode/issues/827
   [gh-834]: https://github.com/jrblevin/markdown-mode/issues/834
   [gh-838]: https://github.com/jrblevin/markdown-mode/issues/838

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2478,6 +2478,16 @@ See GH-275."
     (markdown-test-range-has-face 12 12 'markdown-markup-face)
     (markdown-test-range-has-face 18 18 'markdown-markup-face)))
 
+(ert-deftest test-markdown-font-lock/ignore-uri-in-inline-code ()
+  "Avoid rendering URIs inside inline code."
+  (markdown-test-string
+      "`<http:foo>` t `a <http:bar> b` <http:`bar>` t `<http`:bar>`<http:`bar>"
+    (markdown-test-range-has-face 2 11 'markdown-inline-code-face)
+    (markdown-test-range-has-face 17 30 'markdown-inline-code-face)
+    (markdown-test-range-has-face 40 43 'markdown-inline-code-face)
+    (markdown-test-range-has-face 49 53 'markdown-inline-code-face)
+    (markdown-test-range-has-face 61 66 'markdown-inline-code-face)))
+
 (ert-deftest test-markdown-font-lock/italics-in-reference-definitions ()
   "Test not matching italics in reference definitions across lines."
   (markdown-test-string


### PR DESCRIPTION
## Description

A Markdown like `value=<addr:port>` results in `<addr:port>` suddenly refusing to highlight. This is because the mode recognizes this as an angle URL. Generally speaking, a URL (even an actual one) is not expected to be highlighted inside inline code-blocks, so this commit adds a test for whether start or end is in inline block, to avoid breaking rendering.

A test for this is added as well.

## Related Issue

Fixes: https://github.com/jrblevin/markdown-mode/issues/822

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
