### PR TITLE
Add * to the markdown-mode syntax table as punctuation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
     - Support drag and drop features on Windows and multiple files' drag and drop
     - Added cmark and cmark-gfm to the markdown command list.
     - Disable `imenu-submenus-on-top` by default [GH-882][]
+    - Add $%*+/<=>_|&' to the markdown-mode syntax table as punctuation.
 
   [gh-847]: https://github.com/jrblevin/markdown-mode/issues/847
   [gh-861]: https://github.com/jrblevin/markdown-mode/pull/861

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3721,6 +3721,18 @@ SEQ may be an atom or a sequence."
 (defvar markdown-mode-syntax-table
   (let ((tab (make-syntax-table text-mode-syntax-table)))
     (modify-syntax-entry ?\" "." tab)
+    (modify-syntax-entry ?$ "." tab)  ; Might appear in inline content
+    (modify-syntax-entry ?% "." tab)  ; Could appear in URLs
+    (modify-syntax-entry ?* "." tab)  ; Emphasis (bold/italic)
+    (modify-syntax-entry ?+ "." tab)  ; Used in lists
+    (modify-syntax-entry ?/ "." tab)  ; Might appear in inline content or URLs
+    (modify-syntax-entry ?< "." tab)  ; For autolinks and embedded HTML
+    (modify-syntax-entry ?= "." tab)  ; Underlining in setext headers
+    (modify-syntax-entry ?> "." tab)  ; Blockquotes and HTML
+    (modify-syntax-entry ?_ "." tab)  ; Used for emphasis/bold
+    (modify-syntax-entry ?| "." tab)  ; Used in tables
+    (modify-syntax-entry ?& "." tab)  ; HTML entities
+    (modify-syntax-entry ?' "." tab)  ; Apostrophe as punctuation
     tab)
   "Syntax table for `markdown-mode'.")
 


### PR DESCRIPTION
This commit adds `*` to the markdown-mode syntax table as punctuation. The asterisk is widely used in markdown for emphasis (bold and italic).

## Description

This commit adds `*` to the markdown-mode syntax table as punctuation. The asterisk is widely used in markdown for emphasis (bold and italic).

## Related Issue

Here are an example of issues that this pull request fixes:
- `dabbrev` includes `*` when completing a word surrounded by asterisks.
- The built-in `highlight-symbol-at-point` function highlighting the symbol at the point includes `*`.

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).