### PR TITLE
Change kill-this-buffer to kill-current-buffer

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -10522,7 +10522,7 @@ rows and columns and the column alignment."
     (define-key map (kbd "SPC") #'scroll-up-command)
     (define-key map (kbd ">") #'end-of-buffer)
     (define-key map (kbd "<") #'beginning-of-buffer)
-    (define-key map (kbd "q") #'kill-this-buffer)
+    (define-key map (kbd "q") #'kill-current-buffer)
     (define-key map (kbd "?") #'describe-mode)
     map)
   "Keymap for `markdown-view-mode'.")


### PR DESCRIPTION
Change "q" key binding from kill-this-buffer to kill-current-buffer

## Description

From the docs regarding 'kill-this-buffer':

This command must be bound to a mouse event, and can be reliably invoked only from the menu bar, otherwise it could decide to silently do nothing or signal an error.  Use ‘kill-current-buffer’ if you need to invoke a similar command from keyboard.

## Related Issue

N/A

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed (using `make test`).
