### PR TITLE
Fix wrong list item bound calculation when tab indentation is used

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
     - `markdown-export` should not output stderr content to output file
     - Hide wikilink markup as part of `markdown-toggle-markup-hiding` [GH-847][]
     - Angle URL fontify issue which was introduced by [GH-861][] [GH-895][]
+    - Fix list item bound calculation when tab indentation is used [GH-904][]
 
 *   Improvements:
     - Support drag and drop features on Windows and multiple files' drag and drop
@@ -25,6 +26,7 @@
   [gh-882]: https://github.com/jrblevin/markdown-mode/issues/882
   [gh-891]: https://github.com/jrblevin/markdown-mode/issues/891
   [gh-895]: https://github.com/jrblevin/markdown-mode/issues/895
+  [gh-904]: https://github.com/jrblevin/markdown-mode/issues/904
 
 # Markdown Mode 2.7
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2612,7 +2612,11 @@ Return the point at the end when a list item was found at the
 original point.  If the point is not in a list item, do nothing."
   (let (indent)
     (forward-line)
-    (setq indent (current-indentation))
+    ;; #904 consider a space indentation and tab indentation case
+    (save-excursion
+      (let ((pos (point)))
+        (back-to-indentation)
+        (setq indent (- (point) pos))))
     (while
         (cond
          ;; Stop at end of the buffer.

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -4595,6 +4595,25 @@ puts 'hello, world'
     (forward-line)
     (should (markdown-cur-list-item-bounds))))
 
+(ert-deftest test-markdown-lists/bounds-3 ()
+  "Function `markdown-cur-list-item-bounds' with tab indentations.
+Detail: https://github.com/jrblevin/markdown-mode/issues/904"
+  ;; tab indentation
+  (markdown-test-string "- item
+\t- subitem1
+\t- subitem2"
+    (forward-line)
+    (let ((bounds (markdown-cur-list-item-bounds)))
+      (should (= (nth 1 bounds) 19))))
+
+  ;; space indentation
+  (markdown-test-string "- item
+    - subitem1
+    - subitem2"
+    (forward-line)
+    (let ((bounds (markdown-cur-list-item-bounds)))
+      (should (= (nth 1 bounds) 22)))))
+
 (ert-deftest test-markdown-lists/bounds-prev ()
   "Test list item bounds function `markdown-prev-list-item-bounds'."
   (markdown-test-file "lists.text"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#904

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
