### PR TITLE
Add php-ts-mode to the list of code block languages.

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9201,7 +9201,7 @@ and disable otherwise."
     ("asymptote" . asy-mode) ("dot" . fundamental-mode) ("sqlite" . sql-mode)
     ("calc" . fundamental-mode) ("C" . c-mode) ("cpp" . c++-mode)
     ("C++" . c++-mode) ("screen" . shell-script-mode) ("shell" . sh-mode)
-    ("bash" . sh-mode))
+    ("bash" . sh-mode) ("php" . php-ts-mode))
   "Alist mapping languages to their major mode.
 The key is the language name, the value is the major mode.  For
 many languages this is simple, but for language where this is not


### PR DESCRIPTION
## Description
Title. `php-ts-mode` is a treesit-based major mode introduced in Emacs 30. This change will therefore only work on Emacs 30+ unless you manually backport `php-ts-mode` by installing it as a package.

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves an existing feature)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [X] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [ ] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).
