### PR TITLE
Fix `markdown-heading-at-point` at the end of line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
     - Hide wikilink markup as part of `markdown-toggle-markup-hiding` [GH-847][]
     - Angle URL fontify issue which was introduced by [GH-861][] [GH-895][]
     - Fix list item bound calculation when tab indentation is used [GH-904][]
+    - Fix `markdown-heading-at-point` at the end of line [GH-912][]
 
 *   Improvements:
     - Support drag and drop features on Windows and multiple files' drag and drop
@@ -29,6 +30,7 @@
   [gh-895]: https://github.com/jrblevin/markdown-mode/issues/895
   [gh-904]: https://github.com/jrblevin/markdown-mode/issues/904
   [gh-910]: https://github.com/jrblevin/markdown-mode/issues/910
+  [gh-912]: https://github.com/jrblevin/markdown-mode/issues/912
 
 # Markdown Mode 2.7
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2904,7 +2904,8 @@ data.  See `markdown-inline-code-at-point-p' for inline code."
 (defun markdown-heading-at-point (&optional pos)
   "Return non-nil if there is a heading at the POS.
 Set match data for `markdown-regex-header'."
-  (let ((match-data (get-text-property (or pos (point)) 'markdown-heading)))
+  (let* ((p (or pos (if (and (eolp) (>= (point) 2)) (1- (point)) (point))))
+         (match-data (get-text-property p 'markdown-heading)))
     (when match-data
       (set-match-data match-data)
       t)))

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -4398,7 +4398,11 @@ x: x
       (forward-line -1)
       (should (markdown-heading-at-point))
       (should (equal (match-data t) (get-text-property (point) 'markdown-heading)))
-      (should (equal (match-data t) (get-text-property (point) 'markdown-heading-1-setext))))))
+      (should (equal (match-data t) (get-text-property (point) 'markdown-heading-1-setext))))
+    ;; Detail: https://github.com/jrblevin/markdown-mode/issues/912
+    (markdown-test-string "# header\nsection"
+      (goto-char (line-end-position))
+      (should (markdown-heading-at-point)))))
 
 (ert-deftest test-markdown-parsing/inline-link-in-code-block ()
   "Test `markdown-match-generic-links'."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

#912

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
