### PR TITLE
Fix decoding percent characters in URL issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
     - Fix list item bound calculation when tab indentation is used [GH-904][]
     - Fix `markdown-heading-at-point` at the end of line [GH-912][]
     - Catch an exception when `scan-sexp` fails [GH-917][]
+    - `markdown-link-at-pos` should decode both control characters and spaces [GH-921][]
 
 *   Improvements:
     - Support drag and drop features on Windows and multiple files' drag and drop
@@ -34,6 +35,7 @@
   [gh-910]: https://github.com/jrblevin/markdown-mode/issues/910
   [gh-912]: https://github.com/jrblevin/markdown-mode/issues/912
   [gh-917]: https://github.com/jrblevin/markdown-mode/issues/917
+  [gh-921]: https://github.com/jrblevin/markdown-mode/issues/921
 
 # Markdown Mode 2.7
 

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -5703,6 +5703,16 @@ A link can contain spaces if it is wrapped with angle brackets"
   (markdown-test-string "[text](<bar%20baz.md>)"
     (should (equal (nth 3 (markdown-link-at-pos (point))) "bar baz.md"))))
 
+(ert-deftest test-markdown-link/inline-link-with-percent-encoded-characters ()
+  "Test URL decoding in `markdown-link-at-pos'.
+It should decode only control characters and spaces in URL according
+to CommonMark specification.
+
+Details: https://github.com/jrblevin/markdown-mode/issues/921"
+
+  (markdown-test-string "[text](bar%2F%30baz.md)"
+    (should (string= (nth 3 (markdown-link-at-pos (point))) "bar%2F%30baz.md"))))
+
 (ert-deftest test-markdown-link/reference-link-at-pos ()
   "Test `markdown-link-at-pos' return values with a reference link."
   (markdown-test-string "[text][ref]"


### PR DESCRIPTION
## Description

According to CommonMark specification, we should not decode percent encoded characters in URL except control characters and spaces.

## Related Issue

#921 

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
