### PR TITLE
markdown-preview displays the buffer name as the page title

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 *   Bug fixes:
 
+*   Improvements:
+    - `markdown-preview` displays the buffer name as the page title
 
 # Markdown Mode 2.8
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7799,9 +7799,11 @@ Return the name of the output buffer used."
                       markdown-command exit-code))))
     output-buffer-name))
 
-(defun markdown-standalone (&optional output-buffer-name)
+(defun markdown-standalone (&optional output-buffer-name title)
   "Special function to provide standalone HTML output.
-Insert the output in the buffer named OUTPUT-BUFFER-NAME."
+Insert the output in the buffer named OUTPUT-BUFFER-NAME.
+Set the HTML title to TITLE if provided, otherwise the name of the
+output buffer."
   (interactive)
   (setq output-buffer-name (markdown output-buffer-name))
   (let ((css-path markdown-css-paths))
@@ -7809,7 +7811,7 @@ Insert the output in the buffer named OUTPUT-BUFFER-NAME."
       (set-buffer output-buffer-name)
       (setq-local markdown-css-paths css-path)
       (unless (markdown-output-standalone-p)
-        (markdown-add-xhtml-header-and-footer output-buffer-name))
+        (markdown-add-xhtml-header-and-footer (or title output-buffer-name)))
       (goto-char (point-min))
       (html-mode)))
   output-buffer-name)
@@ -7890,7 +7892,8 @@ When OUTPUT-BUFFER-NAME is given, insert the output in the buffer with
 that name."
   (interactive)
   (browse-url-of-buffer
-   (markdown-standalone (or output-buffer-name markdown-output-buffer-name))))
+   (markdown-standalone (or output-buffer-name markdown-output-buffer-name)
+                        (buffer-name))))
 
 (defun markdown-export-file-name (&optional extension)
   "Attempt to generate a filename for Markdown output.


### PR DESCRIPTION
Set the HTML title of the page generated by `markdown-preview` to be the name of the current buffer. This is likely to be more informative than the current default of `*markdown-output*`.

## Description

<!-- More detailed description of the changes if needed. -->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
