### PR TITLE
Use `markdown--string-width' for aligning table cells

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,12 @@
 *   New Features:
 
 *   Bug fixes:
+    - `markdown-table-align` now handles fullwidth characters correctly [gh-937][]
 
 *   Improvements:
     - `markdown-preview` displays the buffer name as the page title
+
+  [gh-937]: https://github.com/jrblevin/markdown-mode/pull/937
 
 # Markdown Mode 2.8
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -9776,7 +9776,7 @@ This function assumes point is on a table."
        (setq fmt (car fmtspec) fmtspec (cdr fmtspec))
        (setq width (car widths) widths (cdr widths))
        (if (equal fmt 'c)
-           (setq cell (concat (make-string (/ (- width (length cell)) 2) ?\s) cell)))
+           (setq cell (concat (make-string (/ (- width (markdown--string-width cell)) 2) ?\s) cell)))
        (unless (equal fmt 'r) (setq width (- width)))
        (format (format " %%%ds " width) cell))
      cells "|")))

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -7836,6 +7836,21 @@ title: asdasdasd
 | aaa | bbbb | ccccc | dddddd |
 "))))
 
+(ert-deftest test-markdown-table/align-with-fullwidth-characters ()
+  "Test table realignment width fullwidth characters"
+  (markdown-test-string "
+| あ | い | う | え |
+|-|:-|:-:|-:|
+| あああ | いいいい | ううううう | えええええ |
+"
+    (search-forward "あ")
+    (markdown-table-align)
+    (should (string= (buffer-string) "
+| あ     | い       |     う     |         え |
+|--------|:---------|:----------:|-----------:|
+| あああ | いいいい | ううううう | えええええ |
+"))))
+
 (ert-deftest test-markdown-table/align-with-seperator-in-inline-code ()
   "Test table realignment when separator is in inline code.
 Detail: https://github.com/jrblevin/markdown-mode/issues/817"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Use `markdown--string-width` rather than `length` in `markdown-table-align` for aligning cells with fullwidth characters correctly.

<!-- More detailed description of the changes if needed. -->

Example:

```markdown
Expected:

|  あああああ  |
|:------------:|
| ああああああ |

Actual:

|    あああああ |
|:------------:|
|    ああああああ |
```

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [X] I have read the **CONTRIBUTING.md** document.
- [X] I have updated the documentation in the **README.md** file if necessary.
- [X] I have added an entry to **CHANGES.md**.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed (using `make test`).
   The following tests fail on master:
  - `test-markdown-flyspell/check-word-p`
  - `test-markdown-flyspell/remove-overlay`
  - `test-markdown-flyspell/yaml-metadata`

  The new test succeeds on this branch and fails on master as expected.
