### PR TITLE
Improve performance of markdown-range-property-any

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
     - `markdown-preview` displays the buffer name as the page title
     - skip export tests if export command is not installed
     - reduce memory allocations in property checking functions
+    - improve performance to check properties in range by using c functions
 
   [gh-937]: https://github.com/jrblevin/markdown-mode/pull/937
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -2931,19 +2931,16 @@ This may be useful for tables and Pandoc's line_blocks extension."
 Also returns t if PROP is a list containing one of the PROP-VALUES.
 Return nil otherwise."
   (catch 'found
-    (cl-loop
-     with props = nil
-     for loc from begin to end
-     do
-     (when (setq props (get-text-property loc prop))
-       (cond ((listp props)
+    (let ((loc begin))
+      (while (<= loc end)
+        (when-let* ((props (get-text-property loc prop)))
+          (if (listp props)
               ;; props is a list, check for membership
               (dolist (val prop-values)
-                (when (memq val props) (throw 'found loc))))
-             (t
-              ;; props is a scalar, check for equality
-              (dolist (val prop-values)
-                (when (eq val props) (throw 'found loc)))))))))
+                (when (memq val props) (throw 'found loc)))
+            (dolist (val prop-values)
+              (when (eq val props) (throw 'found loc)))))
+        (setq loc (next-single-property-change loc prop nil (1+ end)))))))
 
 (defun markdown-range-properties-exist (begin end props)
   (cl-loop


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

Do not check every position in range in emacs lisp, use c function instead to reduce checking times

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [x] Improvement (non-breaking change which improves an existing feature)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
