### PR TITLE
`markdown-outline-up`:  From top list level, go back to heading

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
     - skip export tests if export command is not installed
     - reduce memory allocations in property checking functions
     - improve performance to check properties in range by using c functions
+    - `markdown-outline-up` goes back to heading from list top level
 
   [gh-937]: https://github.com/jrblevin/markdown-mode/pull/937
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -7512,8 +7512,11 @@ demote."
 (defun markdown-outline-up ()
   "Move to previous list item, when in a list, or previous heading."
   (interactive)
-  (unless (markdown-up-list)
-    (markdown-up-heading 1)))
+  (if (markdown-cur-list-item-bounds)
+      (unless (markdown-up-list)
+	(markdown-back-to-heading))
+      (markdown-up-heading 1)
+    ))
 
 
 ;;; Marking and Narrowing =====================================================


### PR DESCRIPTION
Copy and paste the following into a `markdown-mode` buffer, put the cursor on the `**START HERE** (1)` line; repeated `C-c C-u` jumps to lines (2), (3) and (4).

Before this patch, repeated `C-c C-u` jumps to lines (2) and (4), skipping (3).

```markdown

# (4)  End here
This is header level 1

## Some lev. 2 headers...
Some text...

## (3)  This is header level 2;  C-c C-u does:

`(markdown-up-heading 1)` -> lev. 1 header (4)

(2.1) text

- Some list entries...
- ...
- ...
- (2) This is list level 1;  C-c C-u here does:
  - `(markdown-up-list)` -> text (2.1),
  - then `(markdown-back-to-heading)` -> lev. 2 header (3)
  - ...
  - **START HERE** (1) This is list level 2;:  C-c C-u does:
    - `(markdown-up-list)` -> lev. 1 list item (2)
```

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- More detailed description of the changes if needed. -->

## Related Issue

<!--
For more involved changes, it's probably best to open an issue first
for discussion.  If you are fixing a known bug, please reference the
issue number here or give a link to the issue.
-->

## Type of Change

<!-- Please replace the space with an "x" in all checkboxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [ ] I have added tests to cover my changes.
  - (No existing tests for `markdown-outline-*` functions)
- [x] All new and existing tests passed (using `make test`).
