### PR TITLE
Keep tables visually aligned when hiding markup narrows cells

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
     - `markdown-table-align` now handles fullwidth characters correctly [gh-937][]
 
 *   Improvements:
+    - Tables aligned in the source stay visually aligned when markup
+      hiding or URL hiding narrows the displayed cell contents
     - `markdown-preview` displays the buffer name as the page title
     - skip export tests if export command is not installed
     - reduce memory allocations in property checking functions

--- a/README.md
+++ b/README.md
@@ -601,9 +601,9 @@ prefix.  The most commonly used commands are described below.
         and then splits the data into cells accordingly.
       - <kbd>C-c C-c t</kbd> - Transpose table at point.
 
-    The table editing functions try to handle markup hiding
-    correctly when calculating column widths, however, columns
-    containing hidden markup may not always be aligned properly.
+    When markup hiding is enabled, the display is padded before
+    cell separators so that aligned tables remain visually aligned
+    even when cells contain hidden markup.
 
     <kbd>C-c C-s t</kbd> (`markdown-insert-table`) is a general command for inserting new table.
     The command prompts for table size and column alignment and inserts an empty pipe table at point.

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3636,12 +3636,31 @@ SEQ may be an atom or a sequence."
             (add-text-properties fontified-start fontified-end heading-props)))))
     t))
 
+(defun markdown--fontify-table-alignment ()
+  "Visually align cell separators of the table line at point.
+Hiding markup makes the displayed content of a table cell
+narrower than the buffer text, which breaks the column alignment
+of tables that are aligned in the source.  Give the whitespace
+before each cell separator a space display specification
+stretching it to the separator's buffer column, so that
+separators are displayed at the same column as in the source
+regardless of what is hidden before them."
+  (beginning-of-line)
+  (while (re-search-forward "[ \t]+|" (line-end-position) t)
+    (let ((separator (1- (match-end 0))))
+      (unless (markdown-inline-code-at-pos-p separator)
+        (put-text-property
+         (match-beginning 0) separator
+         'display `(space :align-to ,(1- (current-column))))))))
+
 (defun markdown-fontify-tables (last)
   (when (re-search-forward "|" last t)
     (when (markdown-table-at-point-p)
       (font-lock-append-text-property
        (line-beginning-position) (min (1+ (line-end-position)) (point-max))
-       'face 'markdown-table-face))
+       'face 'markdown-table-face)
+      (when (or markdown-hide-markup markdown-hide-urls)
+        (markdown--fontify-table-alignment)))
     (forward-line 1)
     t))
 

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -2307,6 +2307,48 @@ See GH-245."
       (should (invisible-p 174))
       (should (invisible-p 176)))))
 
+(ert-deftest test-markdown-markup-hiding/table-alignment ()
+  "Test that separators of source-aligned tables stay visually aligned.
+Hidden markup narrows displayed cell contents, so the whitespace
+before each cell separator should stretch to the separator's
+buffer column."
+  (let ((markdown-hide-markup t))
+    (markdown-test-string
+        "| **bold** | b |\n|----------|---|\n| plain    | d |\n"
+      ;; First row, spaces before separators at columns 11 and 15
+      (should (equal (get-text-property 11 'display) '(space :align-to 11)))
+      (should (equal (get-text-property 15 'display) '(space :align-to 15)))
+      ;; Delimiter row has no whitespace, so no display specs
+      (should-not (get-text-property 24 'display))
+      ;; Last row stretches to the same columns as the first row
+      (should (equal (get-text-property 42 'display) '(space :align-to 11)))
+      (should (equal (get-text-property 45 'display) '(space :align-to 11)))
+      (should (equal (get-text-property 49 'display) '(space :align-to 15)))))
+  ;; Without markup hiding, no display specs are added
+  (markdown-test-string
+      "| **bold** | b |\n|----------|---|\n| plain    | d |\n"
+    (should-not (get-text-property 11 'display))
+    (should-not (get-text-property 42 'display))))
+
+(ert-deftest test-markdown-markup-hiding/table-alignment-hidden-urls ()
+  "Test visual table alignment when only URL hiding is enabled."
+  (let ((markdown-hide-urls t))
+    (markdown-test-string
+        "| [a](http://example.com/) | b |\n"
+      (should (equal (get-text-property 27 'display) '(space :align-to 27)))
+      (should (equal (get-text-property 31 'display) '(space :align-to 31))))))
+
+(ert-deftest test-markdown-markup-hiding/table-alignment-inline-code ()
+  "Test that pipes inside inline code are not treated as separators."
+  (let ((markdown-hide-markup t))
+    (markdown-test-string
+        "| `a | b` | c |\n|----------|---|\n"
+      ;; Pipe inside the code span, no display spec on the space before it
+      (should-not (get-text-property 5 'display))
+      ;; Real separators still get aligned
+      (should (equal (get-text-property 10 'display) '(space :align-to 10)))
+      (should (equal (get-text-property 14 'display) '(space :align-to 14))))))
+
 (ert-deftest test-markdown-markup-hiding/escape ()
   "Test hiding markup for backslash escapes."
   (markdown-test-string "\\#"


### PR DESCRIPTION
## Description

I frequently use `markdown-toggle-markup-hiding` to read Markdown files inside Emacs. A small annoyance when enabling that option is that it breaks table alignment when cells contain markup. This patch fixes it at the display layer: during fontification, the whitespace before each cell separator gets a `(space :align-to N)` display spec, where `N` is the separator's buffer column. Pipes of a source-aligned table therefore render at their source columns regardless of how much hidden markup precedes them, and since font-lock manages the `display` property, the specs follow the hiding toggle automatically.

## Related Issue

Fixes #324.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).