### PR TITLE
Fix `gfm-mode` exception when doc ends with unterminated code fence

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@
     - `markdown-table-align` now aligns centered cells
     - Fix highlightings of inline code or bold in strike-through  [GH-926][]
     - Fix fence code block highlighting that uses more than 3 backticks [GH-933][]
+    - Fix `gfm-mode` exception when buffer ends with unterminated code fence [GH-948][]
 
 *   Improvements:
     - Support drag and drop features on Windows and multiple files' drag and drop
@@ -62,6 +63,7 @@
   [gh-926]: https://github.com/jrblevin/markdown-mode/issues/926
   [gh-930]: https://github.com/jrblevin/markdown-mode/issues/930
   [gh-933]: https://github.com/jrblevin/markdown-mode/issues/933
+  [gh-948]: https://github.com/jrblevin/markdown-mode/pull/948
 
 # Markdown Mode 2.7
 

--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4803,7 +4803,8 @@ at the beginning of the block."
        while pos-prop
        for lang = (markdown-code-block-lang pos-prop)
        do (progn (when lang (markdown-gfm-add-used-language lang))
-                 (goto-char (next-single-property-change (point) prop)))))))
+                 (goto-char (or (next-single-property-change (point) prop)
+                                (point-max))))))))
 
 (defun markdown-insert-foldable-block ()
   "Insert details disclosure element to make content foldable.

--- a/tests/markdown-test.el
+++ b/tests/markdown-test.el
@@ -7252,6 +7252,14 @@ x|"
   (markdown-test-string "[|"
     (should-not (gfm--table-at-point-p))))
 
+(ert-deftest test-markdown-gfm/gfm-parse-buffer-for-languages-unterminated-block ()
+  "Don't signal on a buffer whose final line is an unterminated code fence.
+Details: https://github.com/jrblevin/markdown-mode/pull/948"
+  (markdown-test-string-gfm "``` MADEUP"
+    (should (equal markdown-gfm-used-languages (list "MADEUP"))))
+  (markdown-test-string-gfm "``` MADEUP\nfoo\n```\n\n``` LANGUAGES"
+    (should (equal markdown-gfm-used-languages (list "LANGUAGES" "MADEUP")))))
+
 ;;; Tests for other extensions:
 
 (ert-deftest test-markdown-ext/pandoc-fancy-lists ()


### PR DESCRIPTION
## Description

When the buffer's final line is an opening code fence with no trailing newline, the `markdown-gfm-block-begin` property extends to `point-max`, so `next-single-property-change` returns nil and `goto-char` signals.

If the property reaches the end of the buffer, there can be no further blocks to visit, so setting point to `point-max` is safe: on the next iteration, `markdown-find-next-prop` returns nil, and the loop terminates without further ado.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--
Please replace the space with an "x" in all checkboxes that apply.
If you're unsure about any of these, feel free to ask.
-->

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have updated the documentation in the **README.md** file if necessary.
- [x] I have added an entry to **CHANGES.md**.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (using `make test`).
